### PR TITLE
feat: provide ability to disable kong

### DIFF
--- a/charts/supabase/templates/kong/config.yaml
+++ b/charts/supabase/templates/kong/config.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.kong.enable -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -146,4 +147,5 @@ data:
               hide_groups_header: true
               allow:
                 - admin
+{{- end }}
 {{- end }}

--- a/charts/supabase/templates/kong/deployment.yaml
+++ b/charts/supabase/templates/kong/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.kong.enable -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -70,3 +71,4 @@ spec:
             items:
             - key: kong.yml
               path: kong.yml
+{{- end }}

--- a/charts/supabase/templates/kong/ingress.yaml
+++ b/charts/supabase/templates/kong/ingress.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.kong.enable -}}
 {{- if .Values.kong.ingress.enabled -}}
 {{- $fullName := include "supabase.kong.fullname" . -}}
 {{- $svcPort := .Values.kong.service.port -}}
@@ -52,4 +53,5 @@ spec:
               {{- end }}
           {{- end }}
     {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/supabase/templates/kong/service.yaml
+++ b/charts/supabase/templates/kong/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.kong.enable -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -13,3 +14,4 @@ spec:
       name: http
   selector:
     {{- include "supabase.kong.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/supabase/templates/kong/serviceaccount.yaml
+++ b/charts/supabase/templates/kong/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.kong.serviceAccount.create -}}
+{{- if .Values.kong.enable -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/supabase/templates/kong/serviceaccount.yaml
+++ b/charts/supabase/templates/kong/serviceaccount.yaml
@@ -1,12 +1,14 @@
 {{- if .Values.kong.enable -}}
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ include "supabase.kong.serviceAccountName" . }}
-  labels:
-    {{- include "supabase.labels" . | nindent 4 }}
-  {{- with .Values.kong.serviceAccount.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
+  {{- if .Values.kong.serviceAccount.create -}}
+  apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: {{ include "supabase.kong.serviceAccountName" . }}
+    labels:
+      {{- include "supabase.labels" . | nindent 4 }}
+    {{- with .Values.kong.serviceAccount.annotations }}
+    annotations:
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/supabase/values.yaml
+++ b/charts/supabase/values.yaml
@@ -518,6 +518,7 @@ storage:
   affinity: {}
 
 kong:
+  enable: true
   replicaCount: 1
   image:
     repository: kong


### PR DESCRIPTION
This allows end users to optionally provide their own API gateway. Perhaps they already have kong installed on the cluster or would like to use a different one like Ambassador.