### PR TITLE
feat: support for arm64

### DIFF
--- a/charts/supabase/templates/kong/serviceaccount.yaml
+++ b/charts/supabase/templates/kong/serviceaccount.yaml
@@ -1,14 +1,14 @@
 {{- if .Values.kong.enable -}}
-  {{- if .Values.kong.serviceAccount.create -}}
-  apiVersion: v1
-  kind: ServiceAccount
-  metadata:
-    name: {{ include "supabase.kong.serviceAccountName" . }}
-    labels:
-      {{- include "supabase.labels" . | nindent 4 }}
-    {{- with .Values.kong.serviceAccount.annotations }}
-    annotations:
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
+{{- if .Values.kong.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "supabase.kong.serviceAccountName" . }}
+  labels:
+    {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.kong.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/supabase/values.yaml
+++ b/charts/supabase/values.yaml
@@ -428,7 +428,7 @@ storage:
   image:
     repository: supabase/storage-api
     pullPolicy: IfNotPresent
-    tag: "v0.10.0"
+    tag: "v0.18.3"
 
   imagePullSecrets: []
   nameOverride: ""

--- a/charts/supabase/values.yaml
+++ b/charts/supabase/values.yaml
@@ -85,7 +85,7 @@ auth:
   image:
     repository: supabase/gotrue
     pullPolicy: IfNotPresent
-    tag: "v2.2.12"
+    tag: "v2.6.15"
 
   imagePullSecrets: []
   nameOverride: ""
@@ -263,7 +263,7 @@ realtime:
   image:
     repository: supabase/realtime
     pullPolicy: IfNotPresent
-    tag: "v0.19.3"
+    tag: "v0.22.7"
 
   imagePullSecrets: []
   nameOverride: ""
@@ -351,7 +351,7 @@ meta:
   image:
     repository: supabase/postgres-meta
     pullPolicy: IfNotPresent
-    tag: "v0.29.0"
+    tag: "v0.40.0"
 
   imagePullSecrets: []
   nameOverride: ""


### PR DESCRIPTION
Feature+Bugfix for chart `supabase`

**Feature**: support for arm64

the following images found in `values.yml` are out of date and are not compiled for any architecture other than amd64
- supabase/gotrue:v2.2.12
- supabase/realtime:v0.19.3
- supabase/postgres-meta:v0.29.0
- supabase/storage-api:v0.10.0
- tdeoliv/supabase-bitnami-postgres:latest

to fix this issue their default values have been replaced with a more recent version

the last image however (`tdeoliv/supabase-bitnami-postgres`) still isn't built for arm64, @icrotz is it possible to have its Dockerfile publicly accessible or for you to rebuild it?

**Bugfix**: `templates/kong/serviceaccount.yml` was ill-formed triggering the following error:
```
Error: INSTALLATION FAILED: YAML parse error on supabase/templates/kong/serviceaccount.yaml: error converting YAML to JSON: yaml: line 2: mapping values are not allowed in this context
```
