### PR TITLE
feat: add base url for email template

### DIFF
--- a/charts/supabase/values.example.yaml
+++ b/charts/supabase/values.example.yaml
@@ -5,6 +5,7 @@ studio:
   enable: true
   environment:
     SUPABASE_URL: http://api.localhost
+    SUPABASE_REST_URL: http:///api.localhost/rest/v1/ 
     STUDIO_PG_META_URL: http://example-supabase-kong.example-namespace.svc.cluster.local:8000/pg
     SUPABASE_ANON_KEY: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoiYW5vbiIsImlhdCI6MTY0MDMwMDQwMCwiZXhwIjoxNzk4MDY2ODAwfQ.JaEiRNdyxX3Pk6XupxauDazXeadLTgTHz5cV7joUrQE"
     SUPABASE_SERVICE_KEY: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoic2VydmljZV9yb2xlIiwiaWF0IjoxNjQwMzAwNDAwLCJleHAiOjE3OTgwNjY4MDB9.sUJPVrhMsSaLgizyCWIgNOIRmjavxDB4Lm3hzb4dC5U"
@@ -43,6 +44,7 @@ auth:
     GOTRUE_SMTP_SENDER_NAME: "fake_sender"
     GOTRUE_EXTERNAL_PHONE_ENABLED: "false"
     GOTRUE_SMS_AUTOCONFIRM: "false"
+    API_EXTERNAL_URL: http://api.localhost # Used on email template as base URL
 
 rest:
   environment:

--- a/charts/supabase/values.template.yaml
+++ b/charts/supabase/values.template.yaml
@@ -8,6 +8,7 @@ studio:
   # enable: false # Disable the studio
   environment:
     SUPABASE_URL: http://api.localhost
+    SUPABASE_REST_URL: http:///api.localhost/rest/v1/ 
     STUDIO_PG_META_URL: http://RELEASE_NAME-kong.NAMESPACE.svc.cluster.local:8000/pg
     SUPABASE_ANON_KEY: "JWT_ANON_KEY"
     SUPABASE_SERVICE_KEY: "JWT_SERVICE_KEY"
@@ -46,6 +47,7 @@ auth:
     GOTRUE_SMTP_SENDER_NAME: "fake_sender"
     GOTRUE_EXTERNAL_PHONE_ENABLED: "false"
     GOTRUE_SMS_AUTOCONFIRM: "false"
+    API_EXTERNAL_URL: http://api.localhost # Used on email template as base URL
 
 # Rest Service
 rest:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug Fix: Adding base URL for email template

## What is the current behavior?

Email template displays invalid URL, an URL without proper base URL like:
`http:///auth/v1/verify?token=YvLsHrvdGY40zuedjaf-8Q&type=invite&redirect_to=http://example.tld`

## What is the new behavior?

Email template return valid URL with Base URL on it:
`http:///api-example.tld/auth/v1/verify?token=YvLsHrvdGY40zuedjaf-8Q&type=invite&redirect_to=http://studio-example.tld`

## Additional context

Also I add required environment variable `SUPABASE_REST_URL` to make self hosted installation works well
