### PR TITLE
Storage secret

### DIFF
--- a/charts/supabase/templates/storage/deployment.yaml
+++ b/charts/supabase/templates/storage/deployment.yaml
@@ -70,6 +70,7 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.jwt.secretName }}
                   key: serviceKey
+            {{ if .Values.storage.secretName }}
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
@@ -80,6 +81,7 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.storage.secretName }}
                   key: aws_secret_access_key
+            {{ end }}
           ports:
             - name: http
               containerPort: 5000

--- a/charts/supabase/templates/storage/deployment.yaml
+++ b/charts/supabase/templates/storage/deployment.yaml
@@ -70,6 +70,16 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.jwt.secretName }}
                   key: serviceKey
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.storage.secretName }}
+                  key: aws_access_key_id
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.storage.secretName }}
+                  key: aws_secret_access_key
           ports:
             - name: http
               containerPort: 5000

--- a/charts/supabase/values.yaml
+++ b/charts/supabase/values.yaml
@@ -541,7 +541,7 @@ meta:
 # Storage Service
 storage:
   enabled: true # Disable the storage service
-  secretName: "STORAGE_SECRET_NAME"
+  secretName: ""
   image:
     repository: supabase/storage-api
     pullPolicy: IfNotPresent

--- a/charts/supabase/values.yaml
+++ b/charts/supabase/values.yaml
@@ -541,6 +541,7 @@ meta:
 # Storage Service
 storage:
   enabled: true # Disable the storage service
+  secretName: "STORAGE_SECRET_NAME"
   image:
     repository: supabase/storage-api
     pullPolicy: IfNotPresent


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR introduces an optional secret for setting the `AWS_ACCESS_KEY` and `AWS_SECRET_ACCESS_KEY` environment variables for the storage deployment.

## What is the current behavior?

Currently there is no way of setting the access keys.

## What is the new behavior?

if the `storage.secretName` value is set the variables in the secret are set as environment variables.

## Additional context

Add any other context or screenshots.
