### PR TITLE
Fix kong permission and execution errors in wrapper.sh

### DIFF
--- a/charts/supabase/templates/db/storage.yaml
+++ b/charts/supabase/templates/db/storage.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.db.enabled -}}
 {{- if .Values.db.persistence.enabled -}}
 kind: PersistentVolumeClaim
 apiVersion: v1
@@ -17,5 +18,4 @@ spec:
     requests:
       storage: {{ .Values.db.storage.size }}
 {{- end }}
-
-
+{{- end }}

--- a/charts/supabase/templates/kong/config.yaml
+++ b/charts/supabase/templates/kong/config.yaml
@@ -8,17 +8,17 @@ metadata:
 data:
   {{- toYaml .Values.kong.environment | nindent 2 }}
   wrapper.sh: |
-    #!/bin/sh
+    #!/bin/bash
 
     set -euo pipefail
 
-    echo "Replacing env placeholders of /home/kong/kong.yml"
+    echo "Replacing env placeholders of /usr/local/kong/kong.yml"
 
     sed \
     -e "s/\${SUPABASE_ANON_KEY}/${SUPABASE_ANON_KEY}/" \
     -e "s/\${SUPABASE_SERVICE_KEY}/${SUPABASE_SERVICE_KEY}/" \
-    /home/kong/template.yml \
-    > /home/kong/kong.yml
+    /usr/local/kong/template.yml \
+    > /usr/local/kong/kong.yml
 
     exec /docker-entrypoint.sh kong docker-start
 {{- if .Values.kong.config -}}

--- a/charts/supabase/templates/kong/deployment.yaml
+++ b/charts/supabase/templates/kong/deployment.yaml
@@ -63,7 +63,7 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
-            - mountPath: /home/kong/template.yml
+            - mountPath: /usr/local/kong/template.yml
               name: config
               subPath: template.yml
             - mountPath: /scripts

--- a/charts/supabase/templates/kong/deployment.yaml
+++ b/charts/supabase/templates/kong/deployment.yaml
@@ -34,7 +34,7 @@ spec:
             {{- toYaml .Values.kong.securityContext | nindent 12 }}
           image: "{{ .Values.kong.image.repository }}:{{ .Values.kong.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.kong.image.pullPolicy }}
-          command: ["/bin/sh"]
+          command: ["/bin/bash"]
           args: ["/scripts/wrapper.sh"]
           env:
             {{- range $key, $value := .Values.kong.environment }}

--- a/charts/supabase/values.yaml
+++ b/charts/supabase/values.yaml
@@ -667,7 +667,7 @@ kong:
     port: 8000
   environment:
     KONG_DATABASE: "off"
-    KONG_DECLARATIVE_CONFIG: /home/kong/kong.yml
+    KONG_DECLARATIVE_CONFIG: /usr/local/kong/kong.yml
     # https://github.com/supabase/cli/issues/14
     KONG_DNS_ORDER: LAST,A,CNAME
     KONG_PLUGINS: request-transformer,cors,key-auth,acl


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Currently, kong fails to start running with the following error:

```
/scripts/wrapper.sh: 3: set: Illegal option -o pipefail
```
And:

```
/scripts/wrapper.sh: line 8: /home/kong/kong.yml: Permission denied
```

## What is the new behavior?

1. The shebang was adjusted from `/bin/sh` to `/bin/bash` (See https://www.baeldung.com/linux/illegal-option-o-pipefail)
2. kong.yml declarative configuration file was moved from `/home/kong/kong.yml` to `/usr/local/kong/kong.yml`, as well as `/home/kong/template.yml` to `/usr/local/template.yml` in order to run `wrapper.sh` script without permission issues



