### PR TITLE
fixed repo image format of auth

### DIFF
--- a/charts/supabase/values.example.yaml
+++ b/charts/supabase/values.example.yaml
@@ -48,7 +48,8 @@ studio:
 
 auth:
   image:
-    repo: v2.40.1
+    repository: supabase/gotrue
+    tag: v2.40.1
   environment:
     DB_HOST: demo-supabase-db.default.svc.cluster.local
     DB_PORT: "5432"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Current helm isnt capable of being applied to AKS clusters, it seems to not combine the tag and repo name correctly thenless they are split like the others.

## What is the new behavior?

Specifically defined which repo/tag to use allowing the docker pull kubernetes side to function as intended.

## Additional context

As mentioned, when applied currently I experience kubernetes trying to pull the tag as part of the repo name rather than using the tag string as the intended docker tag.
