### PR TITLE
fix error when db persistence enabled (#57)

### DIFF
--- a/charts/supabase/Chart.yaml
+++ b/charts/supabase/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/supabase/templates/db/deployment.yaml
+++ b/charts/supabase/templates/db/deployment.yaml
@@ -134,6 +134,7 @@ spec:
             {{- if .Values.db.persistence.enabled }}
             - mountPath: /var/lib/postgresql/data
               name: postgres-volume
+              subPath: postgres-data
             {{- end }}
           {{- with .Values.db.resources }}
           resources:


### PR DESCRIPTION
## What kind of change does this PR introduce?

bug fix 

## What is the current behavior?

fixes "initdb: error: directory "/var/lib/postgresql/data" exists but is not empty"  errors when db persistence is enabled (#57)

## What is the new behavior?

successful initialisation of the database

## Additional context

Add any other context or screenshots.
