### PR TITLE
Bug fix Supabase storage: use right secret key when providing S3 access keys via secrets

### DIFF
--- a/charts/supabase/templates/storage/deployment.yaml
+++ b/charts/supabase/templates/storage/deployment.yaml
@@ -186,7 +186,7 @@ spec:
                 secretKeyRef:
                 {{- if .Values.secret.s3.secretRef }}
                   name: {{ .Values.secret.s3.secretRef }}
-                  key: {{ .Values.secret.s3.secretRefKey.keyId | default "accessKey" }}
+                  key: {{ .Values.secret.s3.secretRefKey.accessKey | default "accessKey" }}
                 {{- else }}
                   name: {{ include "supabase.secret.s3" . }}
                   key: accessKey


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When providing the S3 access keys via secrets, the keyId is used for both AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY env variables.

## What is the new behavior?

When providing the S3 access keys via secrets, the accessKey is used for the AWS_SECRET_ACCESS_KEY env variable.

## Additional context

None
