### PR TITLE
Feat auth: allow additional secrets as env variables

### DIFF
--- a/charts/supabase/Chart.yaml
+++ b/charts/supabase/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/supabase/templates/auth/deployment.yaml
+++ b/charts/supabase/templates/auth/deployment.yaml
@@ -138,6 +138,10 @@ spec:
                   name: {{ include "supabase.secret.smtp" . }}
                   key: password
                   {{- end }}
+          {{- with .Values.auth.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.auth.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}

--- a/charts/supabase/values.yaml
+++ b/charts/supabase/values.yaml
@@ -311,6 +311,9 @@ auth:
     GOTRUE_MAILER_URLPATHS_CONFIRMATION: "/auth/v1/verify"
     GOTRUE_MAILER_URLPATHS_RECOVERY: "/auth/v1/verify"
     GOTRUE_MAILER_URLPATHS_EMAIL_CHANGE: "/auth/v1/verify"
+  envFrom: []
+    # - secretRef:
+    #     name: env-secret
   # volumeMounts:
   #   - name: volume_name
   #     mountPath: /path/to/my/secret


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

It is currently not possible to pass values of other secrets to the auth service. This means adding external identity providers will cause you to add the secrets in plain text.

## What is the new behavior?

By using envFrom we can reference a secret that contains all the env variables to configure for example an external identity provider.

## Additional context

None
