### PR TITLE
fix edge functions proxy url

### DIFF
--- a/charts/supabase/templates/kong/config.yaml
+++ b/charts/supabase/templates/kong/config.yaml
@@ -177,7 +177,7 @@ data:
     {{- if .Values.functions.enabled }}
       - name: functions-v1
         _comment: 'Edge Functions: /functions/v1/* -> http://{{ include "supabase.functions.fullname" . }}:{{ .Values.functions.service.port }}/*'
-        url: http://functions:{{ .Values.functions.service.port }}/
+        url: http://{{ include "supabase.functions.fullname" . }}:{{ .Values.functions.service.port }}/
         routes:
           - name: functions-v1-all
             strip_path: true


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR includes a fix on Kong edge function URL

## What is the current behavior?

Kong can't resolve edge functions service as is fixed as `functions`

## What is the new behavior?

Kong should be able to resolve edge functions service

