### PR TITLE
Add annotations to kong service

### DIFF
--- a/charts/supabase/Chart.yaml
+++ b/charts/supabase/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/supabase/templates/kong/service.yaml
+++ b/charts/supabase/templates/kong/service.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "supabase.kong.fullname" . }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.kong.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.kong.service.type }}
   ports:

--- a/charts/supabase/values.yaml
+++ b/charts/supabase/values.yaml
@@ -786,6 +786,10 @@ kong:
   service:
     type: ClusterIP
     port: 8000
+    # Annotations to add to the service
+    annotations: {
+      # service.beta.kubernetes.io/azure-pip-name: kong-static-ip-name
+    }
   environment:
     KONG_DATABASE: "off"
     KONG_DECLARATIVE_CONFIG: /usr/local/kong/kong.yml


### PR DESCRIPTION
This way a static IP can be set for the kong service

## What kind of change does this PR introduce?

Allows the addition of annotations for the kong service. This way a static IP can be set.

## Additional context

I bumped the version to 0.1.4 because my other PR #69 already uses version 0.1.3
