### PR TITLE
Fix minio persistence storageClassName

### DIFF
--- a/charts/supabase/templates/minio/volume.yaml
+++ b/charts/supabase/templates/minio/volume.yaml
@@ -11,8 +11,8 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if .Values.minio.persistence.minioClassName }}
-  minioClassName: {{ .Values.minio.persistence.minioClassName }}
+  {{- if .Values.minio.persistence.storageClassName }}
+  storageClassName: {{ .Values.minio.persistence.storageClassName }}
   {{- end }}
   accessModes:
   {{- range .Values.minio.persistence.accessModes }}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

minio persistence from values always use default storageClass

```yaml
spec:
  {{- if .Values.minio.persistence.minioClassName }}
  minioClassName: {{ .Values.minio.persistence.minioClassName }}
  {{- end }}
```

## What is the new behavior?

```yaml
spec:
  {{- if .Values.minio.persistence.storageClassName }}
  storageClassName: {{ .Values.minio.persistence.storageClassName }}
  {{- end }}
```