### PR TITLE
docs: Fix broken link to generate anon and service keys in README.md

### DIFF
--- a/charts/supabase/README.md
+++ b/charts/supabase/README.md
@@ -93,7 +93,7 @@ secret:
 ```
 
 > 32 characters long secret can be generated with `openssl rand 64 | base64`
-> You can use the [JWT Tool](https://supabase.com/docs/guides/hosting/overview#api-keys) to generate anon and service keys.
+> You can use the [JWT Tool](https://supabase.com/docs/guides/self-hosting/docker#generate-api-keys) to generate anon and service keys.
 
 ### SMTP Secret
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

Docs previously pointed to this link, which doesn't point to what it says it does: https://supabase.com/docs/guides/self-hosting#api-keys 

## What is the new behavior?

Docs now point to this link, which contains the anon and secret key generator mentioned in the text around this: https://supabase.com/docs/guides/self-hosting/docker#generate-api-keys

## Additional context

N/A