### PR TITLE
change db into a StatefulSet

### DIFF
--- a/charts/supabase/templates/db/statefulset.yaml
+++ b/charts/supabase/templates/db/statefulset.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.db.enabled -}}
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ include "supabase.db.fullname" . }}
   labels:
@@ -58,6 +58,10 @@ spec:
             {{- toYaml .Values.db.securityContext | nindent 12 }}
           image: "{{ .Values.db.image.repository }}:{{ .Values.db.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.db.image.pullPolicy }}
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "pg_ctl -D /var/lib/postgres/data -w -t 60 -m fast stop"]
           env:
             {{- range $key, $value := .Values.db.environment }}
             - name: {{ $key }}


### PR DESCRIPTION
Changed the DB component into a stateful set. This avoid having two instances of the DB running *on the same data*, which can happen with a deployment (i.e., during an update/reconfiguration).
Also, added a shutdown command to properly shut down the database, to prevent data corruption.

## What kind of change does this PR introduce?

The DB deployment is changed into a StatefulSet. Since there can only be *one* pod mounting and using the data volume at a time, the correct semantic is to use a StatefulSet.

## What is the current behavior?

Using a deployment allows kubernetes to do rolling updates, which mean that a new pod is started *on the same Persistent Volume* while the old one is shutting down. 

That can cause data corruption - which I've personally observed - when upgrading the helm chart.

## What is the new behavior?

In the statefulset semantic, at most only *one* pod can be scheduled to run, so you don't have this issue.
I've also add a lifecycle command so that when the pod is shut down, postgres is commanded to shut down as well, so that it can close in a controlled fashion.

