### PR TITLE
Create default _realtime.tenant on helm install. 

### DIFF
--- a/charts/supabase/templates/realtime/deployment.yaml
+++ b/charts/supabase/templates/realtime/deployment.yaml
@@ -139,7 +139,7 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
             - name: realtime-seed-volume
-              mountPath: /app/lib/realtime-2.30.34/priv/repo/seeds.exs
+              mountPath: /app/lib/realtime-{{ .Values.realtime.image.tag | trimPrefix "v" }}/priv/repo/seeds.exs
               subPath: seeds.exs
       volumes:
       {{- with .Values.realtime.volumes }}

--- a/charts/supabase/templates/realtime/deployment.yaml
+++ b/charts/supabase/templates/realtime/deployment.yaml
@@ -76,6 +76,8 @@ spec:
             - name: DB_HOST
               value: {{ include "supabase.db.fullname" . }}
             {{- end }}
+            - name: TENANT_NAME
+              value: {{ include "supabase.realtime.fullname" . }}
             - name: DB_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -132,14 +134,20 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.realtime.volumeMounts }}
           volumeMounts:
+          {{- with .Values.realtime.volumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
-      {{- with .Values.realtime.volumes }}
+            - name: realtime-seed-volume
+              mountPath: /app/lib/realtime-2.30.34/priv/repo/seeds.exs
+              subPath: seeds.exs
       volumes:
+      {{- with .Values.realtime.volumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
+        - name: realtime-seed-volume
+          configMap:
+            name: {{ printf "%s-seeds" (include "supabase.realtime.fullname" .) }}
       {{- with .Values.realtime.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/supabase/templates/realtime/seeds.yaml
+++ b/charts/supabase/templates/realtime/seeds.yaml
@@ -1,0 +1,66 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ printf "%s-seeds" (include "supabase.realtime.fullname" .) }}
+data:
+  seeds.exs: |
+    require Logger
+    alias Realtime.{Api.Tenant, Repo}
+    import Ecto.Adapters.SQL, only: [query: 3]
+
+    tenant_name = System.get_env("TENANT_NAME", "realtime-dev")
+
+    env = if :ets.whereis(Mix.State) != :undefined, do: Mix.env(), else: :prod
+    default_db_host = if env in [:dev, :test], do: "localhost", else: "host.docker.internal"
+
+    Repo.transaction(fn ->
+    case Repo.get_by(Tenant, external_id: tenant_name) do
+        %Tenant{} = tenant -> Repo.delete!(tenant)
+        nil -> {:ok, nil}
+    end
+
+    %Tenant{}
+    |> Tenant.changeset(%{
+        "name" => tenant_name,
+        "external_id" => tenant_name,
+        "jwt_secret" =>
+        System.get_env("API_JWT_SECRET", "super-secret-jwt-token-with-at-least-32-characters-long"),
+        "jwt_jwks" => System.get_env("API_JWT_JWKS") |> then(fn v -> if v, do: Jason.decode!(v) end),
+        "extensions" => [
+        %{
+            "type" => "postgres_cdc_rls",
+            "settings" => %{
+            "db_name" => System.get_env("DB_NAME", "postgres"),
+            "db_host" => System.get_env("DB_HOST", default_db_host),
+            "db_user" => System.get_env("DB_USER", "supabase_admin"),
+            "db_password" => System.get_env("DB_PASSWORD", "postgres"),
+            "db_port" => System.get_env("DB_PORT", "5433"),
+            "region" => "us-east-1",
+            "poll_interval_ms" => 100,
+            "poll_max_record_bytes" => 1_048_576,
+            "ssl_enforced" => false
+            }
+        }
+        ],
+        "notify_private_alpha" => true
+    })
+    |> Repo.insert!()
+    end)
+
+    if env in [:dev, :test] do
+    publication = "supabase_realtime"
+
+    {:ok, _} =
+        Repo.transaction(fn ->
+        [
+            "drop publication if exists #{publication}",
+            "drop table if exists public.test_tenant;",
+            "create table public.test_tenant ( id SERIAL PRIMARY KEY, details text );",
+            "grant all on table public.test_tenant to anon;",
+            "grant all on table public.test_tenant to postgres;",
+            "grant all on table public.test_tenant to authenticated;",
+            "create publication #{publication} for table public.test_tenant"
+        ]
+        |> Enum.each(&query(Repo, &1, []))
+        end)
+    end


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

the current behavior is that the superbase/realtime image seeds a realtime-dev tenant in _realtime.tenant. In order to make the values.example.yaml work out of the box `realtime.fullnameOverride` must be set to realtime-dev. If the fullnameOverride isn't set, then realtime never works with the default settings in values.example.yaml

## What is the new behavior?

The new behavior updates the realtime pods /priv/repo/seeds.exs to get the TENANT_NAME from environment variables and then defaults to realtime-dev if the environment variable isn't set. 

## Additional context

I am going to submit a PR to the supabase/realtime seeds.exs file, in the meantime this should help with getting running out of the box. 
