### PR TITLE
Bug fix for external database and containers without "latest" tag support.

### DIFF
--- a/charts/supabase/templates/analytics/deployment.yaml
+++ b/charts/supabase/templates/analytics/deployment.yaml
@@ -121,9 +121,11 @@ spec:
               value: {{ .Values.analytics.bigQuery.projectNumber | quote }}
             {{- else }}
             - name: POSTGRES_BACKEND_URL
-              value: $(DB_DRIVER)://$(DB_USERNAME):$(DB_PASSWORD_ENC)@$(DB_HOSTNAME):$(DB_PORT)/$(DB_DATABASE)
+              value: $(DB_DRIVER)://$(DB_USERNAME):$(DB_PASSWORD)@$(DB_HOST):$(DB_PORT)/$(DB_DATABASE)?sslmode=$(DB_SSL)
+            {{- if .Values.analytics.environment.DB_SCHEMA }}
             - name: POSTGRES_BACKEND_SCHEMA
               value: $(DB_SCHEMA)
+            {{- end }}
             - name: LOGFLARE_FEATURE_FLAG_OVERRIDE
               value: $(FEATURE_FLAG_OVERRIDE)
             {{- end }}

--- a/charts/supabase/templates/auth/deployment.yaml
+++ b/charts/supabase/templates/auth/deployment.yaml
@@ -105,7 +105,7 @@ spec:
                   key: database
                   {{- end }}
             - name: GOTRUE_DB_DATABASE_URL
-              value: $(DB_DRIVER)://$(DB_USER):$(DB_PASSWORD_ENC)@$(DB_HOST):$(DB_PORT)/$(DB_NAME)?search_path=auth&sslmode=$(DB_SSL)
+              value: $(DB_DRIVER)://$(DB_USER):$(DB_PASSWORD)@$(DB_HOST):$(DB_PORT)/$(DB_NAME)?search_path=auth&sslmode=$(DB_SSL)
             - name: GOTRUE_DB_DRIVER
               value: $(DB_DRIVER)
             - name: GOTRUE_JWT_SECRET

--- a/charts/supabase/templates/functions/deployment.yaml
+++ b/charts/supabase/templates/functions/deployment.yaml
@@ -110,7 +110,7 @@ spec:
                   key: serviceKey
                   {{- end }}
             - name: POSTGRES_BACKEND_URL
-              value: $(DB_DRIVER)://$(DB_USERNAME):$(DB_PASSWORD_ENC)@$(DB_HOSTNAME):$(DB_PORT)/$(DB_DATABASE)?search_path=auth&sslmode=$(DB_SSL)
+              value: $(DB_DRIVER)://$(DB_USERNAME):$(DB_PASSWORD)@$(DB_HOSTNAME):$(DB_PORT)/$(DB_DATABASE)?search_path=auth&sslmode=$(DB_SSL)
           {{- with .Values.functions.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}

--- a/charts/supabase/templates/rest/deployment.yaml
+++ b/charts/supabase/templates/rest/deployment.yaml
@@ -74,7 +74,7 @@ spec:
                   key: database
                   {{- end }}
             - name: PGRST_DB_URI
-              value: $(DB_DRIVER)://$(DB_USER):$(DB_PASSWORD_ENC)@$(DB_HOST):$(DB_PORT)/$(DB_NAME)?sslmode=$(DB_SSL)
+              value: $(DB_DRIVER)://$(DB_USER):$(DB_PASSWORD)@$(DB_HOST):$(DB_PORT)/$(DB_NAME)?sslmode=$(DB_SSL)
             - name: PGRST_JWT_SECRET
               valueFrom:
                 secretKeyRef:

--- a/charts/supabase/templates/storage/deployment.yaml
+++ b/charts/supabase/templates/storage/deployment.yaml
@@ -135,7 +135,7 @@ spec:
                   key: database
                   {{- end }}
             - name: DATABASE_URL
-              value: $(DB_DRIVER)://$(DB_USER):$(DB_PASSWORD_ENC)@$(DB_HOST):$(DB_PORT)/$(DB_NAME)?search_path=auth&sslmode=$(DB_SSL)
+              value: $(DB_DRIVER)://$(DB_USER):$(DB_PASSWORD)@$(DB_HOST):$(DB_PORT)/$(DB_NAME)?search_path=auth&sslmode=$(DB_SSL)
             - name: PGRST_JWT_SECRET
               valueFrom:
                 secretKeyRef:

--- a/charts/supabase/values.yaml
+++ b/charts/supabase/values.yaml
@@ -887,11 +887,15 @@ analytics:
   environment:
     LOGFLARE_NODE_HOST: 127.0.0.1
     # Override the database hostname if using external database
+    # DB_HOST used for init-db
     # DB_HOST: DATABASE.NAMESPACE.svc.cluster.local
+    # DB_HOSTNAME used for database connection
+    # DB_HOSTNAME: DATABASE.NAMESPACE.svc.cluster.local
     DB_USERNAME: supabase_admin
     DB_PORT: 5432
     DB_DRIVER: postgresql
-    DB_SCHEMA: _analytics
+    DB_SCHEMA: _analytics # Optional
+    DB_SSL: disable # disable, allow, prefer, require, verify-ca, verify-full
     LOGFLARE_SINGLE_TENANT: "true"
     LOGFLARE_SUPABASE_MODE: "true"
     FEATURE_FLAG_OVERRIDE: multibackend=true

--- a/charts/supabase/values.yaml
+++ b/charts/supabase/values.yaml
@@ -252,7 +252,7 @@ auth:
   image:
     repository: supabase/gotrue
     pullPolicy: IfNotPresent
-    tag: "latest"
+    tag: "v2.164.0"
   imagePullSecrets: []
   replicaCount: 1
   nameOverride: ""
@@ -511,7 +511,7 @@ meta:
   image:
     repository: supabase/postgres-meta
     pullPolicy: IfNotPresent
-    tag: "latest"
+    tag: "v0.84.3"
   imagePullSecrets: []
   replicaCount: 1
   nameOverride: ""
@@ -940,7 +940,7 @@ vector:
   image:
     repository: timberio/vector
     pullPolicy: IfNotPresent
-    tag: "latest"
+    tag: "nightly-2024-11-25-alpine"
   imagePullSecrets: []
   replicaCount: 1
   nameOverride: ""
@@ -1007,7 +1007,7 @@ functions:
   image:
     repository: supabase/edge-runtime
     pullPolicy: IfNotPresent
-    tag: "latest"
+    tag: "v1.64.1"
   imagePullSecrets: []
   replicaCount: 1
   nameOverride: ""


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The chart uses tag "latest" for the containers that does not support it.

The chart has a bug integrating external database for Analytics, Auth, functions, rest, and storage.

## What is the new behavior?
The containers that do not support the "latest" tag have specific tag.

The containers for Analytics, Auth, functions, rest, and storage can now connect to external database.

## Additional context

Added DB_SSL environment variable for the Analytics and made the DB_SCHEMA optional.