### PR TITLE
fix(studio): use analytics secretRef if configured

### DIFF
--- a/charts/supabase/templates/studio/deployment.yaml
+++ b/charts/supabase/templates/studio/deployment.yaml
@@ -73,8 +73,13 @@ spec:
             - name: LOGFLARE_API_KEY
               valueFrom:
                 secretKeyRef:
+                  {{- if .Values.secret.analytics.secretRef }}
+                  name: {{ .Values.secret.analytics.secretRef }}
+                  key: {{ .Values.secret.analytics.secretRefKey.apiKey | default "apiKey" }}
+                  {{- else }}
                   name: {{ include "supabase.secret.analytics" . }}
                   key: apiKey
+                  {{- end }}
             {{- end }}
           {{- with .Values.studio.livenessProbe }}
           livenessProbe:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

studio pod fails to start if analytics.secretRef is configured

## What is the new behavior?

studio analytics secret uses same pattern as analytics and vector containers

## Additional context

How has no one hit this before?