### PR TITLE
fix(test-kong): use dashboard secretRef if configured

### DIFF
--- a/charts/supabase/templates/test/kong.yaml
+++ b/charts/supabase/templates/test/kong.yaml
@@ -16,13 +16,23 @@ spec:
             - name: DASHBOARD_USERNAME
               valueFrom:
                 secretKeyRef:
+                  {{- if .Values.secret.dashboard.secretRef }}
+                  name: {{ .Values.secret.dashboard.secretRef }}
+                  key: {{ .Values.secret.dashboard.secretRefKey.username | default "username" }}
+                  {{- else }}
+                  name: {{ include "supabase.secret.dashboard" . }}
                   key: username
-                  name: {{ include "supabase.fullname" . }}-dashboard
+                  {{- end }}
             - name: DASHBOARD_PASSWORD
               valueFrom:
                 secretKeyRef:
+                  {{- if .Values.secret.dashboard.secretRef }}
+                  name: {{ .Values.secret.dashboard.secretRef }}
+                  key: {{ .Values.secret.dashboard.secretRefKey.password | default "password" }}
+                  {{- else }}
+                  name: {{ include "supabase.secret.dashboard" . }}
                   key: password
-                  name: {{ include "supabase.fullname" . }}-dashboard
+                  {{- end }}
           name: test-kong
           image: kdevup/curljq
           imagePullPolicy: IfNotPresent


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

test-kong pod fails to start if dashboard.secretRef is configured

## What is the new behavior?

test-kong dashboard secrets use same pattern as kong

## Additional context

How has no one hit this before?