### PR TITLE
fix(tests): correct syntax for all tests

### DIFF
--- a/charts/supabase/templates/test/analytics.yaml
+++ b/charts/supabase/templates/test/analytics.yaml
@@ -20,7 +20,9 @@ spec:
             - -c
             - |
               curl -sfo /dev/null \
-                http://{{ include "supabase.analytics.fullname" . }}:{{ .Values.analytics.service.port }}/health
+                http://{{ include "supabase.analytics.fullname" . }}:{{ .Values.analytics.service.port }}/health \
+                  || { echo -e "\033[31mFailed to connect to the {{ include "supabase.analytics.fullname" . }}."; exit 1; }
+
               echo "Sevice {{ include "supabase.analytics.fullname" . }} is healthy."
       restartPolicy: Never
 {{- end }}

--- a/charts/supabase/templates/test/auth.yaml
+++ b/charts/supabase/templates/test/auth.yaml
@@ -20,7 +20,9 @@ spec:
             - -c
             - |
               curl -sfo /dev/null \
-                http://{{ include "supabase.auth.fullname" . }}:{{ .Values.auth.service.port }}/health
+                http://{{ include "supabase.auth.fullname" . }}:{{ .Values.auth.service.port }}/health \
+                  || { echo -e "\033[31mFailed to connect to the {{ include "supabase.auth.fullname" . }}."; exit 1; }
+
               echo "Sevice {{ include "supabase.auth.fullname" . }} is healthy."
       restartPolicy: Never
 {{- end }}

--- a/charts/supabase/templates/test/db.yaml
+++ b/charts/supabase/templates/test/db.yaml
@@ -16,9 +16,12 @@ spec:
             - /bin/sh
             - -c
             - |
-              pg_isready -h $(DB_HOST) -p $(DB_PORT) -U $(DB_USER) || $(echo "\e[0;31mFailed to connect to the database." && exit 1)
+              pg_isready -h $(DB_HOST) -p $(DB_PORT) -U $(DB_USER) \
+                || { echo -e "\033[31mFailed to connect to the database."; exit 1; }
+
               echo "Database is ready"
           env:
+          # no password?
             - name: DB_HOST
               {{- if .Values.db.enabled }}
               value: {{ include "supabase.db.fullname" . | quote }}

--- a/charts/supabase/templates/test/imgproxy.yaml
+++ b/charts/supabase/templates/test/imgproxy.yaml
@@ -20,7 +20,9 @@ spec:
             - -c
             - |
               curl -sfo /dev/null \
-                http://{{ include "supabase.imgproxy.fullname" . }}:{{ .Values.imgproxy.service.port }}/health
+                http://{{ include "supabase.imgproxy.fullname" . }}:{{ .Values.imgproxy.service.port }}/health \
+                  || { echo -e "\033[31mFailed to connect to the {{ include "supabase.imgproxy.fullname" . }}."; exit 1; }
+
               echo "Sevice {{ include "supabase.imgproxy.fullname" . }} is healthy."
       restartPolicy: Never
 {{- end }}

--- a/charts/supabase/templates/test/kong.yaml
+++ b/charts/supabase/templates/test/kong.yaml
@@ -34,7 +34,8 @@ spec:
               curl -sL --fail \
                 -o /dev/null \
                 "http://${DASHBOARD_USERNAME}:${DASHBOARD_PASSWORD}@{{ include "supabase.kong.fullname" . }}:{{ .Values.kong.service.port }}" \
-                || ( echo -e "\e[0;31mFailed to get a valid response." && exit 1 )
+                  || { echo -e "\033[31mFailed to connect to the {{ include "supabase.kong.fullname" . }}."; exit 1; }
+
               echo "Successfully connected."
       restartPolicy: Never
 {{- end }}

--- a/charts/supabase/templates/test/meta.yaml
+++ b/charts/supabase/templates/test/meta.yaml
@@ -20,7 +20,9 @@ spec:
             - -c
             - |
               curl -sfo /dev/null \
-                http://{{ include "supabase.meta.fullname" . }}:{{ .Values.meta.service.port }}/health
+                http://{{ include "supabase.meta.fullname" . }}:{{ .Values.meta.service.port }}/health \
+                  || { echo -e "\033[31mFailed to connect to the {{ include "supabase.meta.fullname" . }}."; exit 1; }
+
               echo "Sevice {{ include "supabase.meta.fullname" . }} is healthy."
       restartPolicy: Never
 {{- end }}

--- a/charts/supabase/templates/test/minio.yaml
+++ b/charts/supabase/templates/test/minio.yaml
@@ -19,7 +19,9 @@ spec:
             - -c
             - |
               curl -sfo /dev/null \
-                http://{{ include "supabase.minio.fullname" . }}:{{ .Values.minio.service.port }}/minio/health/live
+                http://{{ include "supabase.minio.fullname" . }}:{{ .Values.minio.service.port }}/minio/health/live \
+                  || { echo -e "\033[31mFailed to connect to the {{ include "supabase.minio.fullname" . }}."; exit 1; }
+
               echo "Sevice {{ include "supabase.minio.fullname" . }} is healthy."
       restartPolicy: Never
 {{- end }}

--- a/charts/supabase/templates/test/realtime.yaml
+++ b/charts/supabase/templates/test/realtime.yaml
@@ -20,7 +20,9 @@ spec:
             - -c
             - |
               curl -sfo /dev/null \
-                http://{{ include "supabase.realtime.fullname" . }}:{{ .Values.realtime.service.port }}
+                http://{{ include "supabase.realtime.fullname" . }}:{{ .Values.realtime.service.port }} \
+                  || { echo -e "\033[31mFailed to connect to the {{ include "supabase.realtime.fullname" . }}."; exit 1; }
+
               echo "Sevice {{ include "supabase.realtime.fullname" . }} is healthy."
       restartPolicy: Never
 {{- end }}

--- a/charts/supabase/templates/test/rest.yaml
+++ b/charts/supabase/templates/test/rest.yaml
@@ -20,7 +20,9 @@ spec:
             - -c
             - |
               curl -sfo /dev/null \
-                http://{{ include "supabase.rest.fullname" . }}:{{ .Values.rest.service.port }}
+                http://{{ include "supabase.rest.fullname" . }}:{{ .Values.rest.service.port }} \
+                  || { echo -e "\033[31mFailed to connect to the {{ include "supabase.rest.fullname" . }}."; exit 1; }
+
               echo "Sevice {{ include "supabase.rest.fullname" . }} is healthy."
       restartPolicy: Never
 {{- end }}

--- a/charts/supabase/templates/test/storage.yaml
+++ b/charts/supabase/templates/test/storage.yaml
@@ -20,7 +20,9 @@ spec:
             - -c
             - |
               curl -sfo /dev/null \
-                http://{{ include "supabase.storage.fullname" . }}:{{ .Values.storage.service.port }}/status
+                http://{{ include "supabase.storage.fullname" . }}:{{ .Values.storage.service.port }}/status \
+                  || { echo -e "\033[31mFailed to connect to the {{ include "supabase.storage.fullname" . }}."; exit 1; }
+
               echo "Sevice {{ include "supabase.storage.fullname" . }} is healthy."
       restartPolicy: Never
 {{- end }}

--- a/charts/supabase/templates/test/studio.yaml
+++ b/charts/supabase/templates/test/studio.yaml
@@ -20,7 +20,9 @@ spec:
             - -c
             - |
               curl -sfo /dev/null \
-                http://{{ include "supabase.studio.fullname" . }}:{{ .Values.studio.service.port }}/api/profile
+                http://{{ include "supabase.studio.fullname" . }}:{{ .Values.studio.service.port }}/api/profile \
+                  || { echo -e "\033[31mFailed to connect to the {{ include "supabase.studio.fullname" . }}."; exit 1; }
+
               echo "Sevice {{ include "supabase.studio.fullname" . }} is healthy."
       restartPolicy: Never
 {{- end }}


### PR DESCRIPTION
**DRAFT**: I haven't had a chance yet to verify all cases

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

All of the tests currently pass even when every service is down due to various syntax errors

## What is the new behavior?

Tests all fail if services are down and pass if they are up

## Additional context

- `$(echo "\e[0;31mFailed to connect to the database." && exit 1)` attempts to execute "Failed" text that comes out of echo
- `( echo -e "\e[0;31mFailed to get a valid response." && exit 1 )` exits the subshell that using parenthesis creates and doesn't pass exit status out to script
- `curl -sfo /dev/null` on its own, with `sh` not being invoked with the `-e` option, doesn't cause the shell to exit with an error code when it fails because it proceeds to the `echo` command which succeeds
