### PR TITLE
Publish helm chart using github pages

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,14 @@
+name: release
+on:
+  push:
+    tags: '*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Publish Helm charts
+        uses: stefanprodan/helm-gh-pages@master
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What kind of change does this PR introduce?
This change enables you to install this chart from terraform. All it require is a new branch named gh-pages. Currently the index.yaml inside the root of this project has invalid urls and is confusing to setup.

This solves the manual process of creating releases and will produce the [output like so](https://hemstreet.github.io/supabase-kubernetes/index.yaml). All on a new tag creation, it will use the chart version vs the actual tag number.

With this change, it would then let you install this chart like so:

```terraform
resource "helm_release" "suspabase" {
  name       = "supabase"
  repository = "https://github.com/supabase-community/supabase-kubernetes"
  chart      = "supabase"
  version    = "0.1.3"

  namespace        = "supabase"
  create_namespace = true
  ...
}
```

You will still need to set values, etc.

Bug fix, feature, docs update, ...

## What is the current behavior?
When running helm install via terraform, You can try to use the raw content url but the tar.gz urls are invalid

https://raw.githubusercontent.com/supabase-community/supabase-kubernetes/refs/heads/main/index.yaml

Please link any relevant issues here.
https://github.com/supabase-community/supabase-kubernetes/issues/76

Fixes this draft from April https://github.com/supabase-community/supabase-kubernetes/pull/55/files


## What is the new behavior?
uses github pages to host the helm charts

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
