### PR TITLE
fix kong configuration for functions service

### DIFF
--- a/charts/supabase/templates/kong/config.yaml
+++ b/charts/supabase/templates/kong/config.yaml
@@ -177,7 +177,7 @@ data:
     {{- if .Values.functions.enabled }}
       - name: functions-v1
         _comment: 'Edge Functions: /functions/v1/* -> http://{{ include "supabase.functions.fullname" . }}:{{ .Values.functions.service.port }}/*'
-        url: http://functions:{{ .Values.functions.service.port }}/
+        url: http://{{ include "supabase.functions.fullname" . }}:{{ .Values.functions.service.port }}/
         routes:
           - name: functions-v1-all
             strip_path: true


### PR DESCRIPTION
## What kind of change does this PR introduce?

Kong configuration is incorrect:  requests to service `supabase-functions` are routed to `functions` which doesn't exists

## What is the current behavior?

Currently configuration for kong is as follows:
```yaml
      - name: functions-v1
        _comment: 'Edge Functions: /functions/v1/* -> http://zupa-supabase-functions:9000/*'
        url: http://functions:9000/
        routes:
          - name: functions-v1-all
            strip_path: true
            paths:
              - /functions/v1/
```
But the `functions` dns name doesn't exists, and it is hardwired in the code.

## What is the new behavior?

Now the configuration is instead using the correct naming used for all other services:
```yaml
      - name: functions-v1
        _comment: 'Edge Functions: /functions/v1/* -> http://zupa-supabase-functions:9000/*'
        url: http://zupa-supabase-functions:9000/
        routes:
          - name: functions-v1-all
            strip_path: true
            paths:
              - /functions/v1/
```
Of course, in this example `zupa-supabase-functions` *is* the name of the service,

## Additional context

```sh
$ kubectl get svc -n supa
NAME                      TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)    AGE
zupa-supabase-analytics   ClusterIP   10.43.231.15    <none>        4000/TCP   4h42m
zupa-supabase-auth        ClusterIP   10.43.125.164   <none>        9999/TCP   97d
zupa-supabase-db          ClusterIP   10.43.226.152   <none>        5432/TCP   97d
zupa-supabase-functions   ClusterIP   10.43.78.210    <none>        9000/TCP   97d
zupa-supabase-imgproxy    ClusterIP   10.43.215.115   <none>        5001/TCP   4h42m
zupa-supabase-kong        ClusterIP   10.43.220.106   <none>        8000/TCP   97d
zupa-supabase-meta        ClusterIP   10.43.144.5     <none>        8080/TCP   97d
zupa-supabase-realtime    ClusterIP   10.43.190.45    <none>        4000/TCP   97d
zupa-supabase-rest        ClusterIP   10.43.59.209    <none>        3000/TCP   97d
zupa-supabase-storage     ClusterIP   10.43.30.150    <none>        5000/TCP   97d
zupa-supabase-studio      ClusterIP   10.43.148.129   <none>        3000/TCP   97d
zupa-supabase-vector      ClusterIP   10.43.198.10    <none>        9001/TCP   4h42m
```

##
Notes: replaces PR #75