### PR TITLE
fix(analytic): external db host

### DIFF
--- a/charts/supabase/templates/analytics/deployment.yaml
+++ b/charts/supabase/templates/analytics/deployment.yaml
@@ -70,10 +70,12 @@ spec:
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
-            {{- if .Values.db.enabled }}
             - name: DB_HOSTNAME
-              value: {{ include "supabase.db.fullname" . }}
-            {{- end }}
+              {{- if .Values.db.enabled }}
+              value: {{ include "supabase.db.fullname" . | quote }}
+              {{- else }}
+              value: {{ .Values.auth.environment.DB_HOST | quote }}
+              {{- end }}
             - name: DB_PASSWORD
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The analytic service `DB_HOSTNAME` env value now only comes from chart's db value. The external db host will be ignored.  

## What is the new behavior?

Correctly use external db_hostname when it's available. 
