### PR TITLE
Add support for custom secretRef keys

### DIFF
--- a/charts/supabase/templates/studio/deployment.yaml
+++ b/charts/supabase/templates/studio/deployment.yaml
@@ -73,8 +73,13 @@ spec:
             - name: LOGFLARE_API_KEY
               valueFrom:
                 secretKeyRef:
+                  {{- if .Values.secret.analytics.secretRef }}
+                  name: {{ .Values.secret.analytics.secretRef }}
+                  key: {{ .Values.secret.analytics.secretRefKey.apiKey | default "apiKey" }}
+                  {{- else }}
                   name: {{ include "supabase.secret.analytics" . }}
                   key: apiKey
+                  {{- end }}                
             {{- end }}
           {{- with .Values.studio.livenessProbe }}
           livenessProbe:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix when replacing  value from secret "secretRef" from values.yaml.

## What is the current behavior?

See: 
https://github.com/supabase-community/supabase-kubernetes/blob/17e14e812fd60a7b5eedb56bf3b359f42ebf91a4/charts/supabase/values.yaml#L48

## What is the new behavior?

If "secretRef" is present, the data from secret will be used.

