### PR TITLE
functions name resolution failed error resolved

### DIFF
--- a/charts/supabase/templates/kong/config.yaml
+++ b/charts/supabase/templates/kong/config.yaml
@@ -177,7 +177,7 @@ data:
     {{- if .Values.functions.enabled }}
       - name: functions-v1
         _comment: 'Edge Functions: /functions/v1/* -> http://{{ include "supabase.functions.fullname" . }}:{{ .Values.functions.service.port }}/*'
-        url: http://functions:{{ .Values.functions.service.port }}/
+        url: http://{{ include "supabase.functions.fullname" . }}:{{ .Values.functions.service.port }}/
         routes:
           - name: functions-v1-all
             strip_path: true


### PR DESCRIPTION
When deployed to k8s using helm, the service name was not picking dynamically according to chart name.

Have removed the hardcoded service and name and added chart name as the URL in kong declarative configuration.

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
