### PR TITLE
Fix Kong wrapper config script sed delimiter to allow using Base64 values

### DIFF
--- a/charts/supabase/templates/kong/config.yaml
+++ b/charts/supabase/templates/kong/config.yaml
@@ -14,10 +14,10 @@ data:
     echo "Replacing env placeholders of /usr/local/kong/kong.yml"
 
     sed \
-    -e "s/\${SUPABASE_ANON_KEY}/${SUPABASE_ANON_KEY}/" \
-    -e "s/\${SUPABASE_SERVICE_KEY}/${SUPABASE_SERVICE_KEY}/" \
-    -e "s/\${DASHBOARD_USERNAME}/${DASHBOARD_USERNAME}/" \
-    -e "s/\${DASHBOARD_PASSWORD}/${DASHBOARD_PASSWORD}/" \
+    -e "s|\${SUPABASE_ANON_KEY}|${SUPABASE_ANON_KEY}|" \
+    -e "s|\${SUPABASE_SERVICE_KEY}|${SUPABASE_SERVICE_KEY}|" \
+    -e "s|\${DASHBOARD_USERNAME}|${DASHBOARD_USERNAME}|" \
+    -e "s|\${DASHBOARD_PASSWORD}|${DASHBOARD_PASSWORD}|" \
     /usr/local/kong/template.yml \
     > /usr/local/kong/kong.yml
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

If any of the env vars among `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_KEY`, `DASHBOARD_USERNAME` or `DASHBOARD_PASSWORD` for Kong happen to be Base64-encoded and/or contain forward slashes, `sed` will fail to process them into a template, throwing a parsing error

## What is the new behavior?

With delimiters replaces by `|` symbols, these may fix an aforementioned issue, but it would become undesirable to use this symbol in any of the environment variables

## Additional context

By all means, it's a quick and dirty fix, as it substitutes one illegal symbol for a less common one. A better fix may be in order that would not rely on using any of the symbols that may break the substitution
