### PR TITLE
fix: use secret.analytics secretKeyRef in studio deployment

### DIFF
--- a/charts/supabase/templates/studio/deployment.yaml
+++ b/charts/supabase/templates/studio/deployment.yaml
@@ -73,8 +73,13 @@ spec:
             - name: LOGFLARE_API_KEY
               valueFrom:
                 secretKeyRef:
+                  {{- if .Values.secret.analytics.secretRef }}
+                  name: {{ .Values.secret.analytics.secretRef }}
+                  key: {{ .Values.secret.analytics.secretRefKey.apiKey | default "apiKey" }}
+                  {{- else }}
                   name: {{ include "supabase.secret.analytics" . }}
                   key: apiKey
+                  {{- end }}
             {{- end }}
           {{- with .Values.studio.livenessProbe }}
           livenessProbe:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

In case Values.secret.analytics.secretRef  is defined it's not used in studio deployment

## What is the new behavior?

Fixed
