### PR TITLE
Make postgres initContainer images configurable via values.yaml

### DIFF
--- a/charts/supabase/templates/analytics/deployment.yaml
+++ b/charts/supabase/templates/analytics/deployment.yaml
@@ -30,8 +30,8 @@ spec:
         {{- toYaml .Values.analytics.podSecurityContext | nindent 8 }}
       initContainers:
         - name: init-db
-          image: postgres:15-alpine
-          imagePullPolicy: IfNotPresent
+          image: "{{ .Values.initContainer.image.repository }}:{{ .Values.initContainer.image.tag }}"
+          imagePullPolicy: {{ .Values.initContainer.image.pullPolicy }}
           env:
             - name: DB_HOST
               {{- if .Values.db.enabled }}

--- a/charts/supabase/templates/auth/deployment.yaml
+++ b/charts/supabase/templates/auth/deployment.yaml
@@ -30,8 +30,8 @@ spec:
         {{- toYaml .Values.auth.podSecurityContext | nindent 8 }}
       initContainers:
         - name: init-db
-          image: postgres:15-alpine
-          imagePullPolicy: IfNotPresent
+          image: "{{ .Values.initContainer.image.repository }}:{{ .Values.initContainer.image.tag }}"
+          imagePullPolicy: {{ .Values.initContainer.image.pullPolicy }}
           env:
             - name: DB_HOST
               {{- if .Values.db.enabled }}

--- a/charts/supabase/templates/realtime/deployment.yaml
+++ b/charts/supabase/templates/realtime/deployment.yaml
@@ -30,8 +30,8 @@ spec:
         {{- toYaml .Values.realtime.podSecurityContext | nindent 8 }}
       initContainers:
         - name: init-db
-          image: postgres:15-alpine
-          imagePullPolicy: IfNotPresent
+          image: "{{ .Values.initContainer.image.repository }}:{{ .Values.initContainer.image.tag }}"
+          imagePullPolicy: {{ .Values.initContainer.image.pullPolicy }}
           env:
             - name: DB_HOST
               {{- if .Values.db.enabled }}

--- a/charts/supabase/templates/storage/deployment.yaml
+++ b/charts/supabase/templates/storage/deployment.yaml
@@ -31,8 +31,8 @@ spec:
         {{- toYaml .Values.storage.podSecurityContext | nindent 8 }}
       initContainers:
         - name: init-db
-          image: postgres:15-alpine
-          imagePullPolicy: IfNotPresent
+          image: "{{ .Values.initContainer.image.repository }}:{{ .Values.initContainer.image.tag }}"
+          imagePullPolicy: {{ .Values.initContainer.image.pullPolicy }}
           env:
             - name: DB_HOST
               {{- if .Values.db.enabled }}

--- a/charts/supabase/templates/test/db.yaml
+++ b/charts/supabase/templates/test/db.yaml
@@ -37,8 +37,8 @@ spec:
                   {{- end }}
             - name: DB_PORT
               value: {{ .Values.auth.environment.DB_PORT | quote }}
-          image: postgres:15-alpine
-          imagePullPolicy: IfNotPresent
+          image: "{{ .Values.initContainer.image.repository }}:{{ .Values.initContainer.image.tag }}"
+          imagePullPolicy: {{ .Values.initContainer.image.pullPolicy }}
           name: test-db
       restartPolicy: Never
 {{- end }}

--- a/charts/supabase/values.yaml
+++ b/charts/supabase/values.yaml
@@ -13,6 +13,13 @@
 # |-- 12. Functions
 # |-- 13. Minio
 
+# Global configuration for initContainer image used across services
+initContainer:
+  image:
+    repository: postgres
+    pullPolicy: IfNotPresent
+    tag: "15-alpine"
+
 secret:
   # jwt will be used to reference secret in multiple services:
   # Anon & Service key: Studio, Storage, Kong


### PR DESCRIPTION
This PR addresses the hardcoded `postgres:15-alpine` images used in initContainers across multiple Supabase services by making them configurable through `values.yaml`.

## Problem
Previously, all initContainers across the Supabase Helm chart used a hardcoded `postgres:15-alpine` image, making it impossible to:
- Use different postgres versions for database connectivity testing
- Use custom postgres images with additional tools or configurations
- Control image pull policies for initContainers
- Use images from private registries

## Solution
Added a new global `initContainer` configuration section to `values.yaml` that follows the same pattern used by other services in the chart:

```yaml
initContainer:
  image:
    repository: postgres
    pullPolicy: IfNotPresent
    tag: "15-alpine"
```

Updated all deployment templates to reference this configurable value instead of the hardcoded image:
- `charts/supabase/templates/analytics/deployment.yaml`
- `charts/supabase/templates/auth/deployment.yaml`
- `charts/supabase/templates/realtime/deployment.yaml`
- `charts/supabase/templates/storage/deployment.yaml`
- `charts/supabase/templates/test/db.yaml`

## Usage Example
Users can now customize the initContainer image in their `values.yaml`:

```yaml
initContainer:
  image:
    repository: postgres
    pullPolicy: Always
    tag: "14"
```

## Backward Compatibility
The change is fully backward compatible - the default values maintain the existing behavior (`postgres:15-alpine` with `IfNotPresent` pull policy).

## Testing
- ✅ Helm lint passes
- ✅ Template generation works correctly
- ✅ Verified custom image configurations are applied correctly
- ✅ All initContainers now use the configured image values

<!-- START COPILOT CODING AGENT SUFFIX -->



<!-- START COPILOT CODING AGENT TIPS -->

---

🤖 This PR was generated by Copilot