### PR TITLE
fix(storage): correct secret key reference for AWS_SECRET_ACCESS_KEY

### DIFF
--- a/charts/supabase/templates/storage/deployment.yaml
+++ b/charts/supabase/templates/storage/deployment.yaml
@@ -186,7 +186,7 @@ spec:
                 secretKeyRef:
                 {{- if .Values.secret.s3.secretRef }}
                   name: {{ .Values.secret.s3.secretRef }}
-                  key: {{ .Values.secret.s3.secretRefKey.keyId | default "accessKey" }}
+                  key: {{ .Values.secret.s3.secretRefKey.accessKey | default "accessKey" }}
                 {{- else }}
                   name: {{ include "supabase.secret.s3" . }}
                   key: accessKey


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The Helm template for AWS_SECRET_ACCESS_KEY incorrectly references
.Values.secret.s3.secretRefKey.keyId instead of .Values.secret.s3.secretRefKey.accessKey.
This causes pods to pull the wrong key from the Kubernetes Secret and fail to authenticate to S3/MinIO.

## What is the new behavior?

- AWS_SECRET_ACCESS_KEY now correctly references .Values.secret.s3.secretRefKey.accessKey | default "accessKey".
- Backward compatibility preserved via default "accessKey".
- Pods can now properly mount credentials and authenticate with S3/MinIO.

## Additional context

Tested locally with helm template to confirm correct Secret key resolution.
This aligns the chart with expected AWS credential naming (keyId for AWS_ACCESS_KEY_ID, accessKey for AWS_SECRET_ACCESS_KEY).
