### PR TITLE
Fix Helm chart installation error caused by missing minio values block on example values

### DIFF
--- a/charts/supabase/values.example.yaml
+++ b/charts/supabase/values.example.yaml
@@ -152,3 +152,10 @@ vector:
 functions:
   image:
     tag: v1.41.2
+
+minio:
+  enabled: true
+  image:
+    tag: RELEASE.2025-09-07T16-13-09Z
+  persistence:
+    enabled: false


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Running `helm install demo -f values.example.yaml .` fails with:

```
Error: INSTALLATION FAILED: template: supabase/templates/test/minio.yaml:1:14:
executing "supabase/templates/test/minio.yaml" at <.Values.minio.enabled>:
nil pointer evaluating interface {}.enabled
```

because the `values.example.yaml` file does not define a `minio:` section.

## What is the new behavior?

Adds a default `minio` configuration block (`enabled: false`) to `values.example.yaml` to prevent Helm from crashing when rendering templates.
Developers can set `enabled: true` when using the built-in MinIO service for local or development setups.

## Additional context
