### PR TITLE
fix(kong): bump declarative config format version to 3.0

### DIFF
--- a/charts/supabase/templates/kong/config.yaml
+++ b/charts/supabase/templates/kong/config.yaml
@@ -39,7 +39,7 @@ data:
 
     exec /entrypoint.sh kong docker-start
   template.yml: |
-    _format_version: '2.1'
+    _format_version: '3.0'
     _transform: true
 
     consumers:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature (compatibility improvement)

## What is the current behavior?

The Kong declarative config template uses `_format_version: '2.1'` while the chart already uses the Kong 3.x entrypoint (`/entrypoint.sh`, updated in https://github.com/supabase-community/supabase-kubernetes/commit/f62ed7c). Kong 3.x auto-upgrades 2.1 configs at startup but emits deprecation warnings.

## What is the new behavior?

Bumps `_format_version` to `'3.0'` to match the Kong 3.x runtime, eliminating deprecation warnings and ensuring forward compatibility.

All routes in this chart use plain prefix paths (e.g., `/auth/v1/`), which are unaffected by the format change. Only regex paths would need a `~` prefix under format 3.0, and the chart has none.

## Additional context

Single-line change. No functional impact — Kong 3.x handles both format versions, but 3.0 is the correct version for the runtime and avoids log noise.

Reference: [Kong Gateway Breaking Changes](https://developer.konghq.com/gateway/breaking-changes/)