### PR TITLE
feat(templates): add optional NetworkPolicy resources for production hardening

### DIFF
--- a/charts/supabase/templates/networkpolicies/auth-networkpolicy.yaml
+++ b/charts/supabase/templates/networkpolicies/auth-networkpolicy.yaml
@@ -1,0 +1,48 @@
+{{- if and (.Values.networkPolicies.enabled | default false) .Values.deployment.auth.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "supabase.auth.fullname" . }}-netpol
+  labels:
+    {{- include "supabase.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "supabase.auth.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+      - podSelector:
+          matchLabels:
+            {{- include "supabase.kong.selectorLabels" . | nindent 12 }}
+      ports:
+      - protocol: TCP
+        port: {{ .Values.service.auth.port | default 9999 }}
+  egress:
+    - to:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: kube-system
+      ports:
+      - protocol: UDP
+        port: 53
+    - to:
+      - namespaceSelector: {}
+      ports:
+      - protocol: TCP
+        port: 5432
+    - to:
+      - namespaceSelector: {}
+      ports:
+      - protocol: TCP
+        port: 587
+      - protocol: TCP
+        port: 465
+    - to:
+      - namespaceSelector: {}
+      ports:
+      - protocol: TCP
+        port: 443
+{{- end }}

--- a/charts/supabase/templates/networkpolicies/kong-networkpolicy.yaml
+++ b/charts/supabase/templates/networkpolicies/kong-networkpolicy.yaml
@@ -1,0 +1,83 @@
+{{- if and (.Values.networkPolicies.enabled | default false) .Values.deployment.kong.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "supabase.kong.fullname" . }}-netpol
+  labels:
+    {{- include "supabase.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "supabase.kong.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+      - namespaceSelector: {}
+      ports:
+      - protocol: TCP
+        port: 8000
+  egress:
+    - to:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: kube-system
+      ports:
+      - protocol: UDP
+        port: 53
+    {{- if .Values.deployment.auth.enabled }}
+    - to:
+      - podSelector:
+          matchLabels:
+            {{- include "supabase.auth.selectorLabels" . | nindent 12 }}
+      ports:
+      - protocol: TCP
+        port: {{ .Values.service.auth.port }}
+    {{- end }}
+    {{- if .Values.deployment.rest.enabled }}
+    - to:
+      - podSelector:
+          matchLabels:
+            {{- include "supabase.rest.selectorLabels" . | nindent 12 }}
+      ports:
+      - protocol: TCP
+        port: {{ .Values.service.rest.port }}
+    {{- end }}
+    {{- if .Values.deployment.realtime.enabled }}
+    - to:
+      - podSelector:
+          matchLabels:
+            {{- include "supabase.realtime.selectorLabels" . | nindent 12 }}
+      ports:
+      - protocol: TCP
+        port: {{ .Values.service.realtime.port }}
+    {{- end }}
+    {{- if .Values.deployment.storage.enabled }}
+    - to:
+      - podSelector:
+          matchLabels:
+            {{- include "supabase.storage.selectorLabels" . | nindent 12 }}
+      ports:
+      - protocol: TCP
+        port: {{ .Values.service.storage.port }}
+    {{- end }}
+    {{- if .Values.deployment.studio.enabled }}
+    - to:
+      - podSelector:
+          matchLabels:
+            {{- include "supabase.studio.selectorLabels" . | nindent 12 }}
+      ports:
+      - protocol: TCP
+        port: {{ .Values.service.studio.port }}
+    {{- end }}
+    {{- if .Values.deployment.meta.enabled }}
+    - to:
+      - podSelector:
+          matchLabels:
+            {{- include "supabase.meta.selectorLabels" . | nindent 12 }}
+      ports:
+      - protocol: TCP
+        port: {{ .Values.service.meta.port }}
+    {{- end }}
+{{- end }}

--- a/charts/supabase/templates/networkpolicies/rest-networkpolicy.yaml
+++ b/charts/supabase/templates/networkpolicies/rest-networkpolicy.yaml
@@ -1,0 +1,36 @@
+{{- if and (.Values.networkPolicies.enabled | default false) .Values.deployment.rest.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "supabase.rest.fullname" . }}-netpol
+  labels:
+    {{- include "supabase.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "supabase.rest.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+      - podSelector:
+          matchLabels:
+            {{- include "supabase.kong.selectorLabels" . | nindent 12 }}
+      ports:
+      - protocol: TCP
+        port: {{ .Values.service.rest.port | default 3000 }}
+  egress:
+    - to:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: kube-system
+      ports:
+      - protocol: UDP
+        port: 53
+    - to:
+      - namespaceSelector: {}
+      ports:
+      - protocol: TCP
+        port: 5432
+{{- end }}

--- a/charts/supabase/values.yaml
+++ b/charts/supabase/values.yaml
@@ -1050,6 +1050,11 @@ migration:
   #   -- Set table owner
   #   alter table app.items owner to :pguser;
 
+## Network Policies
+## When enabled, restricts pod-to-pod communication for defense-in-depth security
+networkPolicies:
+  enabled: false
+
 bigQuery:
   enabled: false
   projectId: google-project-id


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature — production hardening

## What is the current behavior?

All pods can communicate freely with each other and external services. There is no network-level isolation between Supabase components, which means a compromised pod could reach any other service in the namespace.

## What is the new behavior?

Adds optional Kubernetes NetworkPolicy templates for auth, kong, and rest services, controlled by a single toggle: `networkPolicies.enabled` (default: `false`). Existing deployments are unaffected unless explicitly opted in.

When enabled, each policy enforces least-privilege network access:

| Service | Ingress | Egress |
|---------|---------|--------|
| **Auth** | Kong only (port 9999) | DNS, PostgreSQL (5432), SMTP (587/465), HTTPS (443 for OAuth) |
| **Kong** | Any namespace (port 8000) | DNS, all enabled Supabase services on their configured ports |
| **REST** | Kong only (port 3000) | DNS, PostgreSQL (5432) |

**Enable with:**
```yaml
networkPolicies:
  enabled: true
```

## Additional context

This is a defense-in-depth measure for production Kubernetes deployments. The policies are intentionally scoped to the three most security-sensitive services (API gateway, authentication, and database API). Additional services can be covered in follow-up PRs.

All service ports are read from `service.<svc>.port` values rather than hardcoded, ensuring compatibility with custom port configurations.