### PR TITLE
feat(templates): add optional PodDisruptionBudget resources

### DIFF
--- a/charts/supabase/templates/poddisruptionbudgets/auth-pdb.yaml
+++ b/charts/supabase/templates/poddisruptionbudgets/auth-pdb.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.deployment.auth.enabled -}}
+{{- if (.Values.deployment.auth.podDisruptionBudget).enabled -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "supabase.auth.fullname" . }}-pdb
+  labels:
+    {{- include "supabase.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.deployment.auth.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.deployment.auth.podDisruptionBudget.minAvailable }}
+  {{- else if .Values.deployment.auth.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.deployment.auth.podDisruptionBudget.maxUnavailable }}
+  {{- else }}
+  minAvailable: 1
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "supabase.auth.selectorLabels" . | nindent 6 }}
+{{- end }}
+{{- end }}

--- a/charts/supabase/templates/poddisruptionbudgets/kong-pdb.yaml
+++ b/charts/supabase/templates/poddisruptionbudgets/kong-pdb.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.deployment.kong.enabled -}}
+{{- if (.Values.deployment.kong.podDisruptionBudget).enabled -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "supabase.kong.fullname" . }}-pdb
+  labels:
+    {{- include "supabase.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.deployment.kong.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.deployment.kong.podDisruptionBudget.minAvailable }}
+  {{- else if .Values.deployment.kong.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.deployment.kong.podDisruptionBudget.maxUnavailable }}
+  {{- else }}
+  minAvailable: 1
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "supabase.kong.selectorLabels" . | nindent 6 }}
+{{- end }}
+{{- end }}

--- a/charts/supabase/templates/poddisruptionbudgets/rest-pdb.yaml
+++ b/charts/supabase/templates/poddisruptionbudgets/rest-pdb.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.deployment.rest.enabled -}}
+{{- if (.Values.deployment.rest.podDisruptionBudget).enabled -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "supabase.rest.fullname" . }}-pdb
+  labels:
+    {{- include "supabase.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.deployment.rest.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.deployment.rest.podDisruptionBudget.minAvailable }}
+  {{- else if .Values.deployment.rest.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.deployment.rest.podDisruptionBudget.maxUnavailable }}
+  {{- else }}
+  minAvailable: 1
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "supabase.rest.selectorLabels" . | nindent 6 }}
+{{- end }}
+{{- end }}

--- a/charts/supabase/values.yaml
+++ b/charts/supabase/values.yaml
@@ -296,6 +296,10 @@ deployment:
     volumeMounts: {}
     volumes: {}
     resources: {}
+    podDisruptionBudget:
+      enabled: false
+      # minAvailable: 1
+      # maxUnavailable: 1
 
   kong:
     enabled: true
@@ -313,6 +317,10 @@ deployment:
     volumeMounts: {}
     volumes: {}
     resources: {}
+    podDisruptionBudget:
+      enabled: false
+      # minAvailable: 1
+      # maxUnavailable: 1
 
   meta:
     enabled: true
@@ -381,6 +389,10 @@ deployment:
     volumeMounts: {}
     volumes: {}
     resources: {}
+    podDisruptionBudget:
+      enabled: false
+      # minAvailable: 1
+      # maxUnavailable: 1
 
   storage:
     enabled: true


### PR DESCRIPTION
Adds PodDisruptionBudget templates for auth, kong, and rest services, controlled by deployment.<service>.podDisruptionBudget.enabled.

Supports configurable minAvailable or maxUnavailable, defaulting to minAvailable: 1 to ensure at least one pod remains available during voluntary disruptions (node drains, upgrades, etc.).

## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Supabase deployments lack high-availability guarantees during Kubernetes voluntary disruptions (node maintenance, cluster scaling, upgrades). Without PodDisruptionBudgets, Kubernetes eviction controllers can terminate all replicas of a service simultaneously, causing downtime.

## What is the new behavior?

PodDisruptionBudget resources now constrain evictions for Auth, Kong, and REST services. With the default configuration (minAvailable: 1), Kubernetes ensures at least one pod remains running at all times during disruptions, maintaining service availability through infrastructure changes.

Configuration is opt-in via `deployment.<service>.podDisruptionBudget.enabled: true` and supports both minAvailable and maxUnavailable strategies.

## Additional context

PDBs are a production best practice for any multi-replica service. This aligns with Kubernetes recommendations for resilient deployments and supports graceful cluster upgrades and node rotations without service interruption.