### PR TITLE
feat: add manual db migration job with script support

### DIFF
--- a/charts/supabase/templates/db/migration.config.yaml
+++ b/charts/supabase/templates/db/migration.config.yaml
@@ -6,5 +6,5 @@ metadata:
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
 data:
-  {{- toYaml .Values.migration | nindent 2 }}
+  {{- toYaml .Values.migration.config.scripts | nindent 2 }}
 {{- end }}

--- a/charts/supabase/templates/db/migration.job.yaml
+++ b/charts/supabase/templates/db/migration.job.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.deployment.db.enabled .Values.migration.job.enabled -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "supabase.db.fullname" . }}-migrations-job
+spec:
+  backoffLimit: 2
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: runner
+          image: postgres:15-alpine
+          env:
+            - name: DB_HOST
+              value: {{ include "supabase.db.fullname" . }}
+            - name: PGPASSWORD
+              valueFrom: { secretKeyRef: { name: {{ include "supabase.secret.db.name" . }}, key: password } }
+          command: ["/bin/sh", "-c"]
+          args: [ {{ .Values.migration.job.scripts | quote }} ]
+{{- end }}

--- a/charts/supabase/values.yaml
+++ b/charts/supabase/values.yaml
@@ -1056,7 +1056,7 @@ migration:
     # scripts: |
     #   echo "--- Starting Manual Migration ---"
     #   aws s3 cp s3://my-bucket/dump.sql /tmp/dump.sql
-    #   psql -h $DB_HOST -U postgres -f /inline/setup.sql  
+    #   psql -h $DB_HOST -U postgres -f /tmp/dump.sql
     #   echo "--- Finished ---"
 
 bigQuery:

--- a/charts/supabase/values.yaml
+++ b/charts/supabase/values.yaml
@@ -1034,21 +1034,30 @@ serviceAccount:
     name: ""
 
 migration:
-  # example.sql: |
-  #   \set pguser `echo "$POSTGRES_USER"`
+  config:
+    scripts:
+      # example.sql: |
+      #   \set pguser `echo "$POSTGRES_USER"`
 
-  #   -- Create schema
-  #   create schema if not exists app;
-  #   alter schema app owner to :pguser;
+      #   -- Create schema
+      #   create schema if not exists app;
+      #   alter schema app owner to :pguser;
 
-  #   -- Create example table
-  #   create table if not exists app.items (
-  #     id   serial primary key,
-  #     name text not null
-  #   );
+      #   -- Create example table
+      #   create table if not exists app.items (
+      #     id   serial primary key,
+      #     name text not null
+      #   );
 
-  #   -- Set table owner
-  #   alter table app.items owner to :pguser;
+      #   -- Set table owner
+      #   alter table app.items owner to :pguser;
+  job:
+    enabled: false
+    # scripts: |
+    #   echo "--- Starting Manual Migration ---"
+    #   aws s3 cp s3://my-bucket/dump.sql /tmp/dump.sql
+    #   psql -h $DB_HOST -U postgres -f /inline/setup.sql  
+    #   echo "--- Finished ---"
 
 bigQuery:
   enabled: false


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Database initialization and migrations currently rely on ConfigMaps to inject SQL scripts.

Limitation: Kubernetes ConfigMaps are capped at 1MB.

Issue: This prevents users from performing large data migrations or restoring significant database dumps during the deployment process.


## What is the new behavior?

Scripting: Instead of being restricted by etcd's size limits, the job can pull large .sql files directly from external storage (like AWS S3, Azure Storage, volumes etc).

Flexibility: Users can now define a custom scripts block to orchestrate the migration (e.g., downloading the dump, running pre-migration checks, and executing psql).

Backward Compatibility: The existing ConfigMap-based initialization remains untouched for small, schema-only setups.

## Additional context

Production Migrations: Moving data between environments.

Initial Seeding: Populating the Supabase instance with large datasets that exceed the 1MB limit.

Example of migration job enabled 
```
  job:
    enabled: true
```
<img width="2486" height="661" alt="image" src="https://github.com/user-attachments/assets/f5520b84-afbe-4df3-9048-0c42f1e400ea" />

