### PR TITLE
feat: full external database support (secretRefKey host/port + init Job)

### DIFF
--- a/charts/supabase/templates/analytics/deployment.yaml
+++ b/charts/supabase/templates/analytics/deployment.yaml
@@ -36,13 +36,25 @@ spec:
             - name: DB_HOST
               {{- if .Values.deployment.db.enabled }}
               value: {{ include "supabase.db.fullname" . | quote }}
+              {{- else if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "host") }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "supabase.secret.db.name" . }}
+                  key: {{ include "supabase.secret.db.key.host" . }}
               {{- else }}
               value: {{ .Values.environment.analytics.DB_HOST | quote }}
               {{- end }}
             - name: DB_USER
               value: $(DB_USERNAME)
             - name: DB_PORT
+              {{- if and (not .Values.deployment.db.enabled) .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "port") }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "supabase.secret.db.name" . }}
+                  key: {{ include "supabase.secret.db.key.port" . }}
+              {{- else }}
               value: {{ .Values.environment.analytics.DB_PORT | quote }}
+              {{- end }}
           command: ["/bin/sh", "-c"]
           args:
             - |
@@ -59,12 +71,19 @@ spec:
           imagePullPolicy: {{ .Values.image.analytics.pullPolicy }}
           env:
             {{- range $key, $value := .Values.environment.analytics }}
+            {{- if not (and (not $.Values.deployment.db.enabled) $.Values.secret.db.secretRef (or (and (eq $key "DB_HOST") (hasKey (default (dict) $.Values.secret.db.secretRefKey) "host")) (and (eq $key "DB_PORT") (hasKey (default (dict) $.Values.secret.db.secretRefKey) "port")))) }}
             - name: {{ $key }}
               value: {{ $value | quote }}
+            {{- end }}
             {{- end }}
             - name: DB_HOSTNAME
               {{- if .Values.deployment.db.enabled }}
               value: {{ include "supabase.db.fullname" . | quote }}
+              {{- else if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "host") }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "supabase.secret.db.name" . }}
+                  key: {{ include "supabase.secret.db.key.host" . }}
               {{- else }}
               value: {{ .Values.environment.analytics.DB_HOST | quote }}
               {{- end }}

--- a/charts/supabase/templates/analytics/deployment.yaml
+++ b/charts/supabase/templates/analytics/deployment.yaml
@@ -41,6 +41,8 @@ spec:
                 secretKeyRef:
                   name: {{ include "supabase.secret.db.name" . }}
                   key: {{ include "supabase.secret.db.key.host" . }}
+              {{- else if .Values.secret.db.host }}
+              value: {{ .Values.secret.db.host | quote }}
               {{- else }}
               value: {{ .Values.environment.analytics.DB_HOST | quote }}
               {{- end }}
@@ -52,6 +54,8 @@ spec:
                 secretKeyRef:
                   name: {{ include "supabase.secret.db.name" . }}
                   key: {{ include "supabase.secret.db.key.port" . }}
+              {{- else if and (not .Values.deployment.db.enabled) .Values.secret.db.port }}
+              value: {{ .Values.secret.db.port | quote }}
               {{- else }}
               value: {{ .Values.environment.analytics.DB_PORT | quote }}
               {{- end }}
@@ -71,7 +75,7 @@ spec:
           imagePullPolicy: {{ .Values.image.analytics.pullPolicy }}
           env:
             {{- range $key, $value := .Values.environment.analytics }}
-            {{- if not (and (not $.Values.deployment.db.enabled) $.Values.secret.db.secretRef (or (and (eq $key "DB_HOST") (hasKey (default (dict) $.Values.secret.db.secretRefKey) "host")) (and (eq $key "DB_PORT") (hasKey (default (dict) $.Values.secret.db.secretRefKey) "port")))) }}
+            {{- if not (and (not $.Values.deployment.db.enabled) (or (and (eq $key "DB_HOST") (or (and $.Values.secret.db.secretRef (hasKey (default (dict) $.Values.secret.db.secretRefKey) "host")) $.Values.secret.db.host)) (and (eq $key "DB_PORT") (or (and $.Values.secret.db.secretRef (hasKey (default (dict) $.Values.secret.db.secretRefKey) "port")) $.Values.secret.db.port)))) }}
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
@@ -84,6 +88,8 @@ spec:
                 secretKeyRef:
                   name: {{ include "supabase.secret.db.name" . }}
                   key: {{ include "supabase.secret.db.key.host" . }}
+              {{- else if .Values.secret.db.host }}
+              value: {{ .Values.secret.db.host | quote }}
               {{- else }}
               value: {{ .Values.environment.analytics.DB_HOST | quote }}
               {{- end }}

--- a/charts/supabase/templates/auth/deployment.yaml
+++ b/charts/supabase/templates/auth/deployment.yaml
@@ -41,6 +41,8 @@ spec:
                 secretKeyRef:
                   name: {{ include "supabase.secret.db.name" . }}
                   key: {{ include "supabase.secret.db.key.host" . }}
+              {{- else if .Values.secret.db.host }}
+              value: {{ .Values.secret.db.host | quote }}
               {{- else }}
               value: {{ .Values.environment.auth.DB_HOST | quote }}
               {{- end }}
@@ -50,6 +52,8 @@ spec:
                 secretKeyRef:
                   name: {{ include "supabase.secret.db.name" . }}
                   key: {{ include "supabase.secret.db.key.port" . }}
+              {{- else if and (not .Values.deployment.db.enabled) .Values.secret.db.port }}
+              value: {{ .Values.secret.db.port | quote }}
               {{- else }}
               value: {{ .Values.environment.auth.DB_PORT | quote }}
               {{- end }}
@@ -69,7 +73,7 @@ spec:
           imagePullPolicy: {{ .Values.image.auth.pullPolicy }}
           env:
             {{- range $key, $value := .Values.environment.auth }}
-            {{- if not (and (not $.Values.deployment.db.enabled) $.Values.secret.db.secretRef (or (and (eq $key "DB_HOST") (hasKey (default (dict) $.Values.secret.db.secretRefKey) "host")) (and (eq $key "DB_PORT") (hasKey (default (dict) $.Values.secret.db.secretRefKey) "port")))) }}
+            {{- if not (and (not $.Values.deployment.db.enabled) (or (and (eq $key "DB_HOST") (or (and $.Values.secret.db.secretRef (hasKey (default (dict) $.Values.secret.db.secretRefKey) "host")) $.Values.secret.db.host)) (and (eq $key "DB_PORT") (or (and $.Values.secret.db.secretRef (hasKey (default (dict) $.Values.secret.db.secretRefKey) "port")) $.Values.secret.db.port)))) }}
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
@@ -83,6 +87,9 @@ spec:
                 secretKeyRef:
                   name: {{ include "supabase.secret.db.name" . }}
                   key: {{ include "supabase.secret.db.key.host" . }}
+            {{- else if .Values.secret.db.host }}
+            - name: DB_HOST
+              value: {{ .Values.secret.db.host | quote }}
             {{- end }}
             {{- if and (not .Values.deployment.db.enabled) .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "port") }}
             - name: DB_PORT
@@ -90,6 +97,9 @@ spec:
                 secretKeyRef:
                   name: {{ include "supabase.secret.db.name" . }}
                   key: {{ include "supabase.secret.db.key.port" . }}
+            {{- else if and (not .Values.deployment.db.enabled) .Values.secret.db.port }}
+            - name: DB_PORT
+              value: {{ .Values.secret.db.port | quote }}
             {{- end }}
             - name: DB_PASSWORD
               valueFrom:

--- a/charts/supabase/templates/auth/deployment.yaml
+++ b/charts/supabase/templates/auth/deployment.yaml
@@ -102,10 +102,14 @@ spec:
                   name: {{ include "supabase.secret.db.name" . }}
                   key: {{ include "supabase.secret.db.key.passwordEncoded" . }}
             - name: DB_NAME
+              {{- if and .Values.secret.db.secretRef (not (hasKey (default (dict) .Values.secret.db.secretRefKey) "database")) }}
+              value: {{ .Values.secret.db.database | default "postgres" | quote }}
+              {{- else }}
               valueFrom:
                 secretKeyRef:
                   name: {{ include "supabase.secret.db.name" . }}
                   key: {{ include "supabase.secret.db.key.database" . }}
+              {{- end }}
             - name: GOTRUE_DB_DATABASE_URL
               value: $(DB_DRIVER)://$(DB_USER):$(DB_PASSWORD_ENC)@$(DB_HOST):$(DB_PORT)/$(DB_NAME)?search_path=auth&sslmode=$(DB_SSL)
             - name: GOTRUE_DB_DRIVER

--- a/charts/supabase/templates/auth/deployment.yaml
+++ b/charts/supabase/templates/auth/deployment.yaml
@@ -36,11 +36,23 @@ spec:
             - name: DB_HOST
               {{- if .Values.deployment.db.enabled }}
               value: {{ include "supabase.db.fullname" . | quote }}
+              {{- else if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "host") }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "supabase.secret.db.name" . }}
+                  key: {{ include "supabase.secret.db.key.host" . }}
               {{- else }}
               value: {{ .Values.environment.auth.DB_HOST | quote }}
               {{- end }}
             - name: DB_PORT
+              {{- if and (not .Values.deployment.db.enabled) .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "port") }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "supabase.secret.db.name" . }}
+                  key: {{ include "supabase.secret.db.key.port" . }}
+              {{- else }}
               value: {{ .Values.environment.auth.DB_PORT | quote }}
+              {{- end }}
           command: ["/bin/sh", "-c"]
           args:
             - |
@@ -57,12 +69,27 @@ spec:
           imagePullPolicy: {{ .Values.image.auth.pullPolicy }}
           env:
             {{- range $key, $value := .Values.environment.auth }}
+            {{- if not (and (not $.Values.deployment.db.enabled) $.Values.secret.db.secretRef (or (and (eq $key "DB_HOST") (hasKey (default (dict) $.Values.secret.db.secretRefKey) "host")) (and (eq $key "DB_PORT") (hasKey (default (dict) $.Values.secret.db.secretRefKey) "port")))) }}
             - name: {{ $key }}
               value: {{ $value | quote }}
+            {{- end }}
             {{- end }}
             {{- if .Values.deployment.db.enabled }}
             - name: DB_HOST
               value: {{ include "supabase.db.fullname" . }}
+            {{- else if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "host") }}
+            - name: DB_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "supabase.secret.db.name" . }}
+                  key: {{ include "supabase.secret.db.key.host" . }}
+            {{- end }}
+            {{- if and (not .Values.deployment.db.enabled) .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "port") }}
+            - name: DB_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "supabase.secret.db.name" . }}
+                  key: {{ include "supabase.secret.db.key.port" . }}
             {{- end }}
             - name: DB_PASSWORD
               valueFrom:

--- a/charts/supabase/templates/db/init-external-config.yaml
+++ b/charts/supabase/templates/db/init-external-config.yaml
@@ -28,6 +28,11 @@ data:
     CREATE EXTENSION IF NOT EXISTS "uuid-ossp" WITH SCHEMA extensions;
     CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA extensions;
 
+    -- Compatibility: if the external database was created with a custom master username
+    -- (e.g. supabase_admin instead of postgres), the 'postgres' role won't exist.
+    -- Supabase services and upstream GoTrue/PostgREST migrations reference it in grants.
+    DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'postgres') THEN CREATE ROLE postgres NOLOGIN; END IF; END $$;
+
     -- Core API roles
     DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'anon') THEN CREATE ROLE anon NOLOGIN NOINHERIT; END IF; END $$;
     DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'authenticated') THEN CREATE ROLE authenticated NOLOGIN NOINHERIT; END IF; END $$;
@@ -45,12 +50,12 @@ data:
     GRANT authenticated TO authenticator;
     GRANT service_role TO authenticator;
 
-    -- Public schema grants (omit 'postgres' role which may not exist on managed DB)
-    GRANT USAGE ON SCHEMA public TO anon, authenticated, service_role;
-    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO anon, authenticated, service_role;
-    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON FUNCTIONS TO anon, authenticated, service_role;
-    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO anon, authenticated, service_role;
-    GRANT USAGE ON SCHEMA extensions TO anon, authenticated, service_role;
+    -- Public schema grants
+    GRANT USAGE ON SCHEMA public TO postgres, anon, authenticated, service_role;
+    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO postgres, anon, authenticated, service_role;
+    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON FUNCTIONS TO postgres, anon, authenticated, service_role;
+    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO postgres, anon, authenticated, service_role;
+    GRANT USAGE ON SCHEMA extensions TO postgres, anon, authenticated, service_role;
 
     -- API role timeouts
     ALTER ROLE anon SET statement_timeout = '3s';
@@ -84,10 +89,10 @@ data:
     -- Storage schema and supabase_storage_admin role
     CREATE SCHEMA IF NOT EXISTS storage AUTHORIZATION supabase_storage_admin;
     ALTER USER supabase_storage_admin SET search_path = 'storage';
-    GRANT USAGE ON SCHEMA storage TO anon, authenticated, service_role;
-    ALTER DEFAULT PRIVILEGES IN SCHEMA storage GRANT ALL ON TABLES TO anon, authenticated, service_role;
-    ALTER DEFAULT PRIVILEGES IN SCHEMA storage GRANT ALL ON FUNCTIONS TO anon, authenticated, service_role;
-    ALTER DEFAULT PRIVILEGES IN SCHEMA storage GRANT ALL ON SEQUENCES TO anon, authenticated, service_role;
+    GRANT USAGE ON SCHEMA storage TO postgres, anon, authenticated, service_role;
+    ALTER DEFAULT PRIVILEGES IN SCHEMA storage GRANT ALL ON TABLES TO postgres, anon, authenticated, service_role;
+    ALTER DEFAULT PRIVILEGES IN SCHEMA storage GRANT ALL ON FUNCTIONS TO postgres, anon, authenticated, service_role;
+    ALTER DEFAULT PRIVILEGES IN SCHEMA storage GRANT ALL ON SEQUENCES TO postgres, anon, authenticated, service_role;
     GRANT ALL ON SCHEMA storage TO supabase_storage_admin WITH GRANT OPTION;
 
   03-realtime-schema.sql: |

--- a/charts/supabase/templates/db/init-external-config.yaml
+++ b/charts/supabase/templates/db/init-external-config.yaml
@@ -11,58 +11,61 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation
 data:
   00-initial-schema.sql: |
-    -- Supabase initial schema: roles, extensions, and default grants
-    -- Source: https://github.com/supabase/postgres/blob/develop/migrations/db/init-scripts/00000000000000-initial-schema.sql
-
-    -- Set up realtime publication
-    DO $$ BEGIN
-      IF NOT EXISTS (SELECT 1 FROM pg_publication WHERE pubname = 'supabase_realtime') THEN
-        CREATE PUBLICATION supabase_realtime;
-      END IF;
-    END $$;
+    -- Supabase initial schema: roles, extensions, schemas, and default grants.
+    -- Adapted from supabase/postgres init-scripts for external (managed) databases
+    -- such as AWS RDS, Google Cloud SQL, Azure Database, etc.
+    --
+    -- Key differences from the internal DB init:
+    --   - All role creation is idempotent (IF NOT EXISTS)
+    --   - REPLICATION attribute skipped (not available on most managed databases)
+    --   - No reference to 'postgres' role (RDS uses a custom master user)
+    --   - Role passwords set from the DB master password
+    --   - graphql_public schema created for PostgREST
+    --   - All auth functions owned by supabase_auth_admin
 
     -- Extension namespacing
     CREATE SCHEMA IF NOT EXISTS extensions;
     CREATE EXTENSION IF NOT EXISTS "uuid-ossp" WITH SCHEMA extensions;
     CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA extensions;
 
-    -- Auth roles
+    -- Core API roles
     DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'anon') THEN CREATE ROLE anon NOLOGIN NOINHERIT; END IF; END $$;
     DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'authenticated') THEN CREATE ROLE authenticated NOLOGIN NOINHERIT; END IF; END $$;
     DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'service_role') THEN CREATE ROLE service_role NOLOGIN NOINHERIT BYPASSRLS; END IF; END $$;
-    DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'authenticator') THEN CREATE USER authenticator NOINHERIT; END IF; END $$;
-    DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'supabase_replication_admin') THEN CREATE USER supabase_replication_admin WITH LOGIN REPLICATION; END IF; END $$;
-    DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'supabase_read_only_user') THEN CREATE ROLE supabase_read_only_user WITH LOGIN BYPASSRLS; END IF; END $$;
-    DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'dashboard_user') THEN CREATE ROLE dashboard_user NOSUPERUSER CREATEDB CREATEROLE REPLICATION; END IF; END $$;
-    DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'pgbouncer') THEN CREATE USER pgbouncer; END IF; END $$;
 
+    -- Service users
+    DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'authenticator') THEN CREATE USER authenticator NOINHERIT; END IF; END $$;
+    DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'supabase_auth_admin') THEN CREATE USER supabase_auth_admin NOINHERIT CREATEROLE LOGIN NOREPLICATION; END IF; END $$;
+    DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'supabase_storage_admin') THEN CREATE USER supabase_storage_admin NOINHERIT CREATEROLE LOGIN NOREPLICATION; END IF; END $$;
+    DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'pgbouncer') THEN CREATE USER pgbouncer; END IF; END $$;
+    DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'dashboard_user') THEN CREATE ROLE dashboard_user NOSUPERUSER CREATEDB CREATEROLE; END IF; END $$;
+
+    -- Grant API roles to authenticator
     GRANT anon TO authenticator;
     GRANT authenticated TO authenticator;
     GRANT service_role TO authenticator;
 
-    GRANT USAGE ON SCHEMA public TO postgres, anon, authenticated, service_role;
-    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO postgres, anon, authenticated, service_role;
-    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON FUNCTIONS TO postgres, anon, authenticated, service_role;
-    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO postgres, anon, authenticated, service_role;
-    GRANT USAGE ON SCHEMA extensions TO postgres, anon, authenticated, service_role;
+    -- Public schema grants (omit 'postgres' role which may not exist on managed DB)
+    GRANT USAGE ON SCHEMA public TO anon, authenticated, service_role;
+    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO anon, authenticated, service_role;
+    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON FUNCTIONS TO anon, authenticated, service_role;
+    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO anon, authenticated, service_role;
+    GRANT USAGE ON SCHEMA extensions TO anon, authenticated, service_role;
 
+    -- API role timeouts
     ALTER ROLE anon SET statement_timeout = '3s';
     ALTER ROLE authenticated SET statement_timeout = '8s';
 
   01-auth-schema.sql: |
-    -- Supabase auth schema and supabase_auth_admin role
-    -- Source: https://github.com/supabase/postgres/blob/develop/migrations/db/init-scripts/00000000000001-auth-schema.sql
-
-    CREATE SCHEMA IF NOT EXISTS auth;
-
-    DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'supabase_auth_admin') THEN CREATE USER supabase_auth_admin NOINHERIT CREATEROLE LOGIN NOREPLICATION; END IF; END $$;
-
+    -- Auth schema, supabase_auth_admin role, and auth helper functions
+    CREATE SCHEMA IF NOT EXISTS auth AUTHORIZATION supabase_auth_admin;
     GRANT ALL PRIVILEGES ON SCHEMA auth TO supabase_auth_admin;
     ALTER USER supabase_auth_admin SET search_path = 'auth';
-
     GRANT USAGE ON SCHEMA auth TO anon, authenticated, service_role;
 
-    -- auth.uid(), auth.role(), auth.email() functions used by RLS policies
+    -- Auth helper functions (owned by supabase_auth_admin to avoid permission issues)
+    SET ROLE supabase_auth_admin;
+
     CREATE OR REPLACE FUNCTION auth.uid() RETURNS uuid AS $$
       SELECT nullif(current_setting('request.jwt.claim.sub', true), '')::uuid;
     $$ LANGUAGE sql STABLE;
@@ -75,41 +78,71 @@ data:
       SELECT nullif(current_setting('request.jwt.claim.email', true), '')::text;
     $$ LANGUAGE sql STABLE;
 
+    RESET ROLE;
+
   02-storage-schema.sql: |
-    -- Supabase storage schema and supabase_storage_admin role
-    -- Source: https://github.com/supabase/postgres/blob/develop/migrations/db/init-scripts/00000000000002-storage-schema.sql
-
-    CREATE SCHEMA IF NOT EXISTS storage;
-
-    DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'supabase_storage_admin') THEN CREATE USER supabase_storage_admin NOINHERIT CREATEROLE LOGIN NOREPLICATION; END IF; END $$;
+    -- Storage schema and supabase_storage_admin role
+    CREATE SCHEMA IF NOT EXISTS storage AUTHORIZATION supabase_storage_admin;
     ALTER USER supabase_storage_admin SET search_path = 'storage';
-
-    GRANT USAGE ON SCHEMA storage TO postgres, anon, authenticated, service_role;
-    ALTER DEFAULT PRIVILEGES IN SCHEMA storage GRANT ALL ON TABLES TO postgres, anon, authenticated, service_role;
-    ALTER DEFAULT PRIVILEGES IN SCHEMA storage GRANT ALL ON FUNCTIONS TO postgres, anon, authenticated, service_role;
-    ALTER DEFAULT PRIVILEGES IN SCHEMA storage GRANT ALL ON SEQUENCES TO postgres, anon, authenticated, service_role;
+    GRANT USAGE ON SCHEMA storage TO anon, authenticated, service_role;
+    ALTER DEFAULT PRIVILEGES IN SCHEMA storage GRANT ALL ON TABLES TO anon, authenticated, service_role;
+    ALTER DEFAULT PRIVILEGES IN SCHEMA storage GRANT ALL ON FUNCTIONS TO anon, authenticated, service_role;
+    ALTER DEFAULT PRIVILEGES IN SCHEMA storage GRANT ALL ON SEQUENCES TO anon, authenticated, service_role;
     GRANT ALL ON SCHEMA storage TO supabase_storage_admin WITH GRANT OPTION;
 
   03-realtime-schema.sql: |
-    -- Supabase realtime schema
+    -- Realtime and graphql_public schemas
     CREATE SCHEMA IF NOT EXISTS _realtime;
+    CREATE SCHEMA IF NOT EXISTS graphql_public;
+    GRANT USAGE ON SCHEMA graphql_public TO anon, authenticated, service_role;
 
-  04-post-setup.sql: |
-    -- Supabase post-setup: search paths, dashboard user grants
-    -- Source: https://github.com/supabase/postgres/blob/develop/migrations/db/init-scripts/00000000000003-post-setup.sql
+    -- Realtime publication
+    DO $$ BEGIN
+      IF NOT EXISTS (SELECT 1 FROM pg_publication WHERE pubname = 'supabase_realtime') THEN
+        CREATE PUBLICATION supabase_realtime;
+      END IF;
+    END $$;
 
-    GRANT ALL ON DATABASE {{ .Values.secret.db.database | default "postgres" }} TO dashboard_user;
-    GRANT ALL ON SCHEMA auth TO dashboard_user;
-    GRANT ALL ON SCHEMA extensions TO dashboard_user;
-    GRANT ALL ON ALL TABLES IN SCHEMA auth TO dashboard_user;
-    GRANT ALL ON ALL TABLES IN SCHEMA extensions TO dashboard_user;
-    GRANT ALL ON ALL SEQUENCES IN SCHEMA auth TO dashboard_user;
-    GRANT ALL ON ALL SEQUENCES IN SCHEMA extensions TO dashboard_user;
-    GRANT ALL ON ALL ROUTINES IN SCHEMA auth TO dashboard_user;
-    GRANT ALL ON ALL ROUTINES IN SCHEMA extensions TO dashboard_user;
+  04-passwords-and-grants.sql: |
+    -- Set all service role passwords to the master DB password.
+    -- This matches the behavior of the internal Supabase DB 99-roles.sql init script.
+    -- The password is injected via the DB_PASSWORD environment variable in the init Job.
+
+    -- NOTE: This script uses CURRENT_USER's password as the source. The init Job connects
+    -- as the DB master user, so all service roles get the same password. In production,
+    -- consider using unique passwords per role via additional secrets.
+
+    DO $$
+    DECLARE
+      master_pass text;
+    BEGIN
+      -- Get current user's password from pg_shadow (already authenticated)
+      -- We set all service passwords to match for simplicity
+      EXECUTE format('ALTER USER authenticator WITH PASSWORD %L', current_setting('supabase.db_password', true));
+      EXECUTE format('ALTER USER supabase_auth_admin WITH PASSWORD %L', current_setting('supabase.db_password', true));
+      EXECUTE format('ALTER USER supabase_storage_admin WITH PASSWORD %L', current_setting('supabase.db_password', true));
+      EXECUTE format('ALTER USER pgbouncer WITH PASSWORD %L', current_setting('supabase.db_password', true));
+    EXCEPTION WHEN OTHERS THEN
+      RAISE NOTICE 'Could not set role passwords via GUC. Set them manually or pass the password via the init Job environment.';
+    END $$;
+
+    -- Dashboard user grants
+    DO $$ BEGIN
+      IF EXISTS (SELECT FROM pg_roles WHERE rolname = 'dashboard_user') THEN
+        GRANT ALL ON SCHEMA auth TO dashboard_user;
+        GRANT ALL ON SCHEMA extensions TO dashboard_user;
+        GRANT ALL ON ALL TABLES IN SCHEMA auth TO dashboard_user;
+        GRANT ALL ON ALL TABLES IN SCHEMA extensions TO dashboard_user;
+        GRANT ALL ON ALL SEQUENCES IN SCHEMA auth TO dashboard_user;
+        GRANT ALL ON ALL SEQUENCES IN SCHEMA extensions TO dashboard_user;
+        GRANT ALL ON ALL ROUTINES IN SCHEMA auth TO dashboard_user;
+        GRANT ALL ON ALL ROUTINES IN SCHEMA extensions TO dashboard_user;
+      END IF;
+    END $$;
 
     DO $$ BEGIN
-      IF EXISTS (SELECT FROM pg_namespace WHERE nspname = 'storage') THEN
+      IF EXISTS (SELECT FROM pg_roles WHERE rolname = 'dashboard_user') AND
+         EXISTS (SELECT FROM pg_namespace WHERE nspname = 'storage') THEN
         GRANT ALL ON SCHEMA storage TO dashboard_user;
         GRANT ALL ON ALL SEQUENCES IN SCHEMA storage TO dashboard_user;
         GRANT ALL ON ALL ROUTINES IN SCHEMA storage TO dashboard_user;

--- a/charts/supabase/templates/db/init-external-config.yaml
+++ b/charts/supabase/templates/db/init-external-config.yaml
@@ -65,7 +65,11 @@ data:
 
   01-auth-schema.sql: |
     -- Auth schema, supabase_auth_admin role, and auth helper functions
-    CREATE SCHEMA IF NOT EXISTS auth AUTHORIZATION supabase_auth_admin;
+    -- Grant membership so current user can SET ROLE
+    GRANT supabase_auth_admin TO CURRENT_USER;
+
+    CREATE SCHEMA IF NOT EXISTS auth;
+    ALTER SCHEMA auth OWNER TO supabase_auth_admin;
     GRANT ALL PRIVILEGES ON SCHEMA auth TO supabase_auth_admin;
     ALTER USER supabase_auth_admin SET search_path = 'auth';
     GRANT USAGE ON SCHEMA auth TO anon, authenticated, service_role;
@@ -89,7 +93,11 @@ data:
 
   02-storage-schema.sql: |
     -- Storage schema and supabase_storage_admin role
-    CREATE SCHEMA IF NOT EXISTS storage AUTHORIZATION supabase_storage_admin;
+    -- Grant membership so current user can SET ROLE
+    GRANT supabase_storage_admin TO CURRENT_USER;
+
+    CREATE SCHEMA IF NOT EXISTS storage;
+    ALTER SCHEMA storage OWNER TO supabase_storage_admin;
     ALTER USER supabase_storage_admin SET search_path = 'storage';
     GRANT USAGE ON SCHEMA storage TO postgres, anon, authenticated, service_role;
     ALTER DEFAULT PRIVILEGES IN SCHEMA storage GRANT ALL ON TABLES TO postgres, anon, authenticated, service_role;

--- a/charts/supabase/templates/db/init-external-config.yaml
+++ b/charts/supabase/templates/db/init-external-config.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": post-install
+    "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "-5"
     "helm.sh/hook-delete-policy": before-hook-creation
 data:

--- a/charts/supabase/templates/db/init-external-config.yaml
+++ b/charts/supabase/templates/db/init-external-config.yaml
@@ -30,10 +30,11 @@ data:
     CREATE EXTENSION IF NOT EXISTS "uuid-ossp" WITH SCHEMA extensions;
     CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA extensions;
 
-    -- Compatibility: if the external database was created with a custom master username
-    -- (e.g. supabase_admin instead of postgres), the 'postgres' role won't exist.
-    -- Supabase services and upstream GoTrue/PostgREST migrations reference it in grants.
+    -- Compatibility roles: ensure both 'postgres' and 'supabase_admin' exist regardless
+    -- of which was used as the master username. Supabase services connect as supabase_admin
+    -- and upstream migrations reference postgres in grants.
     DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'postgres') THEN CREATE ROLE postgres NOLOGIN; END IF; END $$;
+    DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'supabase_admin') THEN CREATE USER supabase_admin CREATEDB CREATEROLE LOGIN BYPASSRLS; END IF; END $$;
 
     -- Core API roles
     DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'anon') THEN CREATE ROLE anon NOLOGIN NOINHERIT; END IF; END $$;

--- a/charts/supabase/templates/db/init-external-config.yaml
+++ b/charts/supabase/templates/db/init-external-config.yaml
@@ -1,0 +1,118 @@
+{{- if not .Values.deployment.db.enabled -}}
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ include "supabase.fullname" . }}-db-init-external
+  labels:
+    {{- include "supabase.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation
+data:
+  00-initial-schema.sql: |
+    -- Supabase initial schema: roles, extensions, and default grants
+    -- Source: https://github.com/supabase/postgres/blob/develop/migrations/db/init-scripts/00000000000000-initial-schema.sql
+
+    -- Set up realtime publication
+    DO $$ BEGIN
+      IF NOT EXISTS (SELECT 1 FROM pg_publication WHERE pubname = 'supabase_realtime') THEN
+        CREATE PUBLICATION supabase_realtime;
+      END IF;
+    END $$;
+
+    -- Extension namespacing
+    CREATE SCHEMA IF NOT EXISTS extensions;
+    CREATE EXTENSION IF NOT EXISTS "uuid-ossp" WITH SCHEMA extensions;
+    CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA extensions;
+
+    -- Auth roles
+    DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'anon') THEN CREATE ROLE anon NOLOGIN NOINHERIT; END IF; END $$;
+    DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'authenticated') THEN CREATE ROLE authenticated NOLOGIN NOINHERIT; END IF; END $$;
+    DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'service_role') THEN CREATE ROLE service_role NOLOGIN NOINHERIT BYPASSRLS; END IF; END $$;
+    DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'authenticator') THEN CREATE USER authenticator NOINHERIT; END IF; END $$;
+    DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'supabase_replication_admin') THEN CREATE USER supabase_replication_admin WITH LOGIN REPLICATION; END IF; END $$;
+    DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'supabase_read_only_user') THEN CREATE ROLE supabase_read_only_user WITH LOGIN BYPASSRLS; END IF; END $$;
+    DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'dashboard_user') THEN CREATE ROLE dashboard_user NOSUPERUSER CREATEDB CREATEROLE REPLICATION; END IF; END $$;
+    DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'pgbouncer') THEN CREATE USER pgbouncer; END IF; END $$;
+
+    GRANT anon TO authenticator;
+    GRANT authenticated TO authenticator;
+    GRANT service_role TO authenticator;
+
+    GRANT USAGE ON SCHEMA public TO postgres, anon, authenticated, service_role;
+    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO postgres, anon, authenticated, service_role;
+    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON FUNCTIONS TO postgres, anon, authenticated, service_role;
+    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO postgres, anon, authenticated, service_role;
+    GRANT USAGE ON SCHEMA extensions TO postgres, anon, authenticated, service_role;
+
+    ALTER ROLE anon SET statement_timeout = '3s';
+    ALTER ROLE authenticated SET statement_timeout = '8s';
+
+  01-auth-schema.sql: |
+    -- Supabase auth schema and supabase_auth_admin role
+    -- Source: https://github.com/supabase/postgres/blob/develop/migrations/db/init-scripts/00000000000001-auth-schema.sql
+
+    CREATE SCHEMA IF NOT EXISTS auth;
+
+    DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'supabase_auth_admin') THEN CREATE USER supabase_auth_admin NOINHERIT CREATEROLE LOGIN NOREPLICATION; END IF; END $$;
+
+    GRANT ALL PRIVILEGES ON SCHEMA auth TO supabase_auth_admin;
+    ALTER USER supabase_auth_admin SET search_path = 'auth';
+
+    GRANT USAGE ON SCHEMA auth TO anon, authenticated, service_role;
+
+    -- auth.uid(), auth.role(), auth.email() functions used by RLS policies
+    CREATE OR REPLACE FUNCTION auth.uid() RETURNS uuid AS $$
+      SELECT nullif(current_setting('request.jwt.claim.sub', true), '')::uuid;
+    $$ LANGUAGE sql STABLE;
+
+    CREATE OR REPLACE FUNCTION auth.role() RETURNS text AS $$
+      SELECT nullif(current_setting('request.jwt.claim.role', true), '')::text;
+    $$ LANGUAGE sql STABLE;
+
+    CREATE OR REPLACE FUNCTION auth.email() RETURNS text AS $$
+      SELECT nullif(current_setting('request.jwt.claim.email', true), '')::text;
+    $$ LANGUAGE sql STABLE;
+
+  02-storage-schema.sql: |
+    -- Supabase storage schema and supabase_storage_admin role
+    -- Source: https://github.com/supabase/postgres/blob/develop/migrations/db/init-scripts/00000000000002-storage-schema.sql
+
+    CREATE SCHEMA IF NOT EXISTS storage;
+
+    DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'supabase_storage_admin') THEN CREATE USER supabase_storage_admin NOINHERIT CREATEROLE LOGIN NOREPLICATION; END IF; END $$;
+    ALTER USER supabase_storage_admin SET search_path = 'storage';
+
+    GRANT USAGE ON SCHEMA storage TO postgres, anon, authenticated, service_role;
+    ALTER DEFAULT PRIVILEGES IN SCHEMA storage GRANT ALL ON TABLES TO postgres, anon, authenticated, service_role;
+    ALTER DEFAULT PRIVILEGES IN SCHEMA storage GRANT ALL ON FUNCTIONS TO postgres, anon, authenticated, service_role;
+    ALTER DEFAULT PRIVILEGES IN SCHEMA storage GRANT ALL ON SEQUENCES TO postgres, anon, authenticated, service_role;
+    GRANT ALL ON SCHEMA storage TO supabase_storage_admin WITH GRANT OPTION;
+
+  03-realtime-schema.sql: |
+    -- Supabase realtime schema
+    CREATE SCHEMA IF NOT EXISTS _realtime;
+
+  04-post-setup.sql: |
+    -- Supabase post-setup: search paths, dashboard user grants
+    -- Source: https://github.com/supabase/postgres/blob/develop/migrations/db/init-scripts/00000000000003-post-setup.sql
+
+    GRANT ALL ON DATABASE {{ .Values.secret.db.database | default "postgres" }} TO dashboard_user;
+    GRANT ALL ON SCHEMA auth TO dashboard_user;
+    GRANT ALL ON SCHEMA extensions TO dashboard_user;
+    GRANT ALL ON ALL TABLES IN SCHEMA auth TO dashboard_user;
+    GRANT ALL ON ALL TABLES IN SCHEMA extensions TO dashboard_user;
+    GRANT ALL ON ALL SEQUENCES IN SCHEMA auth TO dashboard_user;
+    GRANT ALL ON ALL SEQUENCES IN SCHEMA extensions TO dashboard_user;
+    GRANT ALL ON ALL ROUTINES IN SCHEMA auth TO dashboard_user;
+    GRANT ALL ON ALL ROUTINES IN SCHEMA extensions TO dashboard_user;
+
+    DO $$ BEGIN
+      IF EXISTS (SELECT FROM pg_namespace WHERE nspname = 'storage') THEN
+        GRANT ALL ON SCHEMA storage TO dashboard_user;
+        GRANT ALL ON ALL SEQUENCES IN SCHEMA storage TO dashboard_user;
+        GRANT ALL ON ALL ROUTINES IN SCHEMA storage TO dashboard_user;
+      END IF;
+    END $$;
+{{- end }}

--- a/charts/supabase/templates/db/init-external-config.yaml
+++ b/charts/supabase/templates/db/init-external-config.yaml
@@ -9,6 +9,8 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "-5"
     "helm.sh/hook-delete-policy": before-hook-creation
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
 data:
   00-initial-schema.sql: |
     -- Supabase initial schema: roles, extensions, schemas, and default grants.
@@ -108,29 +110,7 @@ data:
       END IF;
     END $$;
 
-  04-passwords-and-grants.sql: |
-    -- Set all service role passwords to the master DB password.
-    -- This matches the behavior of the internal Supabase DB 99-roles.sql init script.
-    -- The password is injected via the DB_PASSWORD environment variable in the init Job.
-
-    -- NOTE: This script uses CURRENT_USER's password as the source. The init Job connects
-    -- as the DB master user, so all service roles get the same password. In production,
-    -- consider using unique passwords per role via additional secrets.
-
-    DO $$
-    DECLARE
-      master_pass text;
-    BEGIN
-      -- Get current user's password from pg_shadow (already authenticated)
-      -- We set all service passwords to match for simplicity
-      EXECUTE format('ALTER USER authenticator WITH PASSWORD %L', current_setting('supabase.db_password', true));
-      EXECUTE format('ALTER USER supabase_auth_admin WITH PASSWORD %L', current_setting('supabase.db_password', true));
-      EXECUTE format('ALTER USER supabase_storage_admin WITH PASSWORD %L', current_setting('supabase.db_password', true));
-      EXECUTE format('ALTER USER pgbouncer WITH PASSWORD %L', current_setting('supabase.db_password', true));
-    EXCEPTION WHEN OTHERS THEN
-      RAISE NOTICE 'Could not set role passwords via GUC. Set them manually or pass the password via the init Job environment.';
-    END $$;
-
+  04-grants.sql: |
     -- Dashboard user grants
     DO $$ BEGIN
       IF EXISTS (SELECT FROM pg_roles WHERE rolname = 'dashboard_user') THEN

--- a/charts/supabase/templates/db/init-external-job.yaml
+++ b/charts/supabase/templates/db/init-external-job.yaml
@@ -9,6 +9,8 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": before-hook-creation
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
 spec:
   ttlSecondsAfterFinished: 86400
   backoffLimit: 3
@@ -31,12 +33,23 @@ spec:
                 sleep 2
               done
 
+              CONNSTR="sslmode=require host=$DB_HOST port=$DB_PORT user=$DB_USER dbname=$DB_NAME"
+
               echo "Running Supabase init scripts against external database..."
-              export PGOPTIONS="-c supabase.db_password=$DB_PASSWORD"
               for f in /init-scripts/*.sql; do
                 echo "=== Running $(basename $f) ==="
-                PGPASSWORD="$DB_PASSWORD" psql "sslmode=require host=$DB_HOST port=$DB_PORT user=$DB_USER dbname=$DB_NAME" -f "$f" -v ON_ERROR_STOP=0
+                PGPASSWORD="$DB_PASSWORD" psql "$CONNSTR" -f "$f" -v ON_ERROR_STOP=0
               done
+
+              echo "Setting service role passwords..."
+              PGPASSWORD="$DB_PASSWORD" psql "$CONNSTR" -v ON_ERROR_STOP=0 <<EOSQL
+              ALTER USER authenticator WITH PASSWORD '$DB_PASSWORD';
+              ALTER USER supabase_auth_admin WITH PASSWORD '$DB_PASSWORD';
+              ALTER USER supabase_storage_admin WITH PASSWORD '$DB_PASSWORD';
+              ALTER USER pgbouncer WITH PASSWORD '$DB_PASSWORD';
+              GRANT supabase_admin TO authenticator;
+              EOSQL
+
               echo "=== External database initialization complete ==="
           env:
             - name: DB_HOST
@@ -58,7 +71,7 @@ spec:
               value: {{ .Values.environment.auth.DB_PORT | default "5432" | quote }}
               {{- end }}
             - name: DB_USER
-              value: {{ .Values.environment.auth.DB_USER | default "supabase_admin" | quote }}
+              value: {{ .Values.environment.auth.DB_USER | default "postgres" | quote }}
             - name: DB_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/supabase/templates/db/init-external-job.yaml
+++ b/charts/supabase/templates/db/init-external-job.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": post-install
+    "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": before-hook-creation
 spec:

--- a/charts/supabase/templates/db/init-external-job.yaml
+++ b/charts/supabase/templates/db/init-external-job.yaml
@@ -1,0 +1,83 @@
+{{- if not .Values.deployment.db.enabled -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "supabase.fullname" . }}-db-init
+  labels:
+    {{- include "supabase.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  ttlSecondsAfterFinished: 86400
+  backoffLimit: 3
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: init-external-db
+          image: "{{ .Values.image.initDb.repository }}:{{ .Values.image.initDb.tag }}"
+          imagePullPolicy: {{ .Values.image.initDb.pullPolicy }}
+          command:
+            - sh
+            - -c
+            - |
+              set -e
+
+              echo "Waiting for database to be ready..."
+              until pg_isready -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER"; do
+                echo "Database not ready, retrying in 2s..."
+                sleep 2
+              done
+
+              echo "Running Supabase init scripts against external database..."
+              for f in /init-scripts/*.sql; do
+                echo "=== Running $(basename $f) ==="
+                PGPASSWORD="$DB_PASSWORD" psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" -f "$f" -v ON_ERROR_STOP=0
+              done
+              echo "=== External database initialization complete ==="
+          env:
+            - name: DB_HOST
+              {{- if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "host") }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "supabase.secret.db.name" . }}
+                  key: {{ include "supabase.secret.db.key.host" . }}
+              {{- else }}
+              value: {{ .Values.environment.auth.DB_HOST | default "" | quote }}
+              {{- end }}
+            - name: DB_PORT
+              {{- if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "port") }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "supabase.secret.db.name" . }}
+                  key: {{ include "supabase.secret.db.key.port" . }}
+              {{- else }}
+              value: {{ .Values.environment.auth.DB_PORT | default "5432" | quote }}
+              {{- end }}
+            - name: DB_USER
+              value: {{ .Values.environment.auth.DB_USER | default "supabase_admin" | quote }}
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "supabase.secret.db.name" . }}
+                  key: {{ include "supabase.secret.db.key.password" . }}
+            - name: DB_NAME
+              {{- if .Values.secret.db.secretRef }}
+              value: {{ .Values.secret.db.database | default "postgres" | quote }}
+              {{- else }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "supabase.secret.db.name" . }}
+                  key: {{ include "supabase.secret.db.key.database" . }}
+              {{- end }}
+          volumeMounts:
+            - name: init-scripts
+              mountPath: /init-scripts
+              readOnly: true
+      volumes:
+        - name: init-scripts
+          configMap:
+            name: {{ include "supabase.fullname" . }}-db-init-external
+{{- end }}

--- a/charts/supabase/templates/db/init-external-job.yaml
+++ b/charts/supabase/templates/db/init-external-job.yaml
@@ -71,7 +71,14 @@ spec:
               value: {{ .Values.environment.auth.DB_PORT | default "5432" | quote }}
               {{- end }}
             - name: DB_USER
-              value: {{ .Values.environment.auth.DB_USER | default "postgres" | quote }}
+              {{- if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "username") }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "supabase.secret.db.name" . }}
+                  key: {{ index (default (dict) .Values.secret.db.secretRefKey) "username" }}
+              {{- else }}
+              value: "postgres"
+              {{- end }}
             - name: DB_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/supabase/templates/db/init-external-job.yaml
+++ b/charts/supabase/templates/db/init-external-job.yaml
@@ -32,9 +32,10 @@ spec:
               done
 
               echo "Running Supabase init scripts against external database..."
+              export PGOPTIONS="-c supabase.db_password=$DB_PASSWORD"
               for f in /init-scripts/*.sql; do
                 echo "=== Running $(basename $f) ==="
-                PGPASSWORD="$DB_PASSWORD" psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" -f "$f" -v ON_ERROR_STOP=0
+                PGPASSWORD="$DB_PASSWORD" psql "sslmode=require host=$DB_HOST port=$DB_PORT user=$DB_USER dbname=$DB_NAME" -f "$f" -v ON_ERROR_STOP=0
               done
               echo "=== External database initialization complete ==="
           env:

--- a/charts/supabase/templates/db/init-external-job.yaml
+++ b/charts/supabase/templates/db/init-external-job.yaml
@@ -33,7 +33,7 @@ spec:
                 sleep 2
               done
 
-              CONNSTR="sslmode=require host=$DB_HOST port=$DB_PORT user=$DB_USER dbname=$DB_NAME"
+              CONNSTR="sslmode=${DB_SSL:-prefer} host=$DB_HOST port=$DB_PORT user=$DB_USER dbname=$DB_NAME"
 
               echo "Running Supabase init scripts against external database..."
               for f in /init-scripts/*.sql; do
@@ -62,6 +62,8 @@ spec:
                 secretKeyRef:
                   name: {{ include "supabase.secret.db.name" . }}
                   key: {{ include "supabase.secret.db.key.host" . }}
+              {{- else if .Values.secret.db.host }}
+              value: {{ .Values.secret.db.host | quote }}
               {{- else }}
               value: {{ .Values.environment.auth.DB_HOST | default "" | quote }}
               {{- end }}
@@ -71,6 +73,8 @@ spec:
                 secretKeyRef:
                   name: {{ include "supabase.secret.db.name" . }}
                   key: {{ include "supabase.secret.db.key.port" . }}
+              {{- else if .Values.secret.db.port }}
+              value: {{ .Values.secret.db.port | quote }}
               {{- else }}
               value: {{ .Values.environment.auth.DB_PORT | default "5432" | quote }}
               {{- end }}
@@ -89,7 +93,7 @@ spec:
                   name: {{ include "supabase.secret.db.name" . }}
                   key: {{ include "supabase.secret.db.key.password" . }}
             - name: DB_NAME
-              {{- if .Values.secret.db.secretRef }}
+              {{- if and .Values.secret.db.secretRef (not (hasKey (default (dict) .Values.secret.db.secretRefKey) "database")) }}
               value: {{ .Values.secret.db.database | default "postgres" | quote }}
               {{- else }}
               valueFrom:
@@ -97,6 +101,8 @@ spec:
                   name: {{ include "supabase.secret.db.name" . }}
                   key: {{ include "supabase.secret.db.key.database" . }}
               {{- end }}
+            - name: DB_SSL
+              value: {{ .Values.environment.auth.DB_SSL | default "prefer" | quote }}
           volumeMounts:
             - name: init-scripts
               mountPath: /init-scripts

--- a/charts/supabase/templates/db/init-external-job.yaml
+++ b/charts/supabase/templates/db/init-external-job.yaml
@@ -41,13 +41,15 @@ spec:
                 PGPASSWORD="$DB_PASSWORD" psql "$CONNSTR" -f "$f" -v ON_ERROR_STOP=0
               done
 
-              echo "Setting service role passwords..."
+              echo "Setting service role passwords and grants..."
               PGPASSWORD="$DB_PASSWORD" psql "$CONNSTR" -v ON_ERROR_STOP=0 <<EOSQL
               ALTER USER authenticator WITH PASSWORD '$DB_PASSWORD';
               ALTER USER supabase_auth_admin WITH PASSWORD '$DB_PASSWORD';
               ALTER USER supabase_storage_admin WITH PASSWORD '$DB_PASSWORD';
               ALTER USER pgbouncer WITH PASSWORD '$DB_PASSWORD';
-              GRANT supabase_admin TO authenticator;
+              GRANT $DB_USER TO authenticator;
+              GRANT CREATE ON DATABASE $DB_NAME TO supabase_storage_admin;
+              GRANT CREATE ON DATABASE $DB_NAME TO supabase_auth_admin;
               EOSQL
 
               echo "=== External database initialization complete ==="

--- a/charts/supabase/templates/db/init-external-job.yaml
+++ b/charts/supabase/templates/db/init-external-job.yaml
@@ -47,7 +47,9 @@ spec:
               ALTER USER supabase_auth_admin WITH PASSWORD '$DB_PASSWORD';
               ALTER USER supabase_storage_admin WITH PASSWORD '$DB_PASSWORD';
               ALTER USER pgbouncer WITH PASSWORD '$DB_PASSWORD';
+              ALTER USER supabase_admin WITH PASSWORD '$DB_PASSWORD';
               GRANT $DB_USER TO authenticator;
+              GRANT $DB_USER TO supabase_admin;
               GRANT CREATE ON DATABASE $DB_NAME TO supabase_storage_admin;
               GRANT CREATE ON DATABASE $DB_NAME TO supabase_auth_admin;
               EOSQL

--- a/charts/supabase/templates/functions/deployment.yaml
+++ b/charts/supabase/templates/functions/deployment.yaml
@@ -70,10 +70,14 @@ spec:
                   name: {{ include "supabase.secret.db.name" . }}
                   key: {{ include "supabase.secret.db.key.passwordEncoded" . }}
             - name: DB_DATABASE
+              {{- if and .Values.secret.db.secretRef (not (hasKey (default (dict) .Values.secret.db.secretRefKey) "database")) }}
+              value: {{ .Values.secret.db.database | default "postgres" | quote }}
+              {{- else }}
               valueFrom:
                 secretKeyRef:
                   name: {{ include "supabase.secret.db.name" . }}
                   key: {{ include "supabase.secret.db.key.database" . }}
+              {{- end }}
             - name: JWT_SECRET
               valueFrom:
                 secretKeyRef:

--- a/charts/supabase/templates/meta/deployment.yaml
+++ b/charts/supabase/templates/meta/deployment.yaml
@@ -64,10 +64,14 @@ spec:
                   name: {{ include "supabase.secret.db.name" . }}
                   key: {{ include "supabase.secret.db.key.password" . }}
             - name: DB_NAME
+              {{- if and .Values.secret.db.secretRef (not (hasKey (default (dict) .Values.secret.db.secretRefKey) "database")) }}
+              value: {{ .Values.secret.db.database | default "postgres" | quote }}
+              {{- else }}
               valueFrom:
                 secretKeyRef:
                   name: {{ include "supabase.secret.db.name" . }}
                   key: {{ include "supabase.secret.db.key.database" . }}
+              {{- end }}
             - name: PG_META_DB_HOST
               value: $(DB_HOST)
             - name: PG_META_DB_PORT

--- a/charts/supabase/templates/meta/deployment.yaml
+++ b/charts/supabase/templates/meta/deployment.yaml
@@ -36,12 +36,27 @@ spec:
           imagePullPolicy: {{ .Values.image.meta.pullPolicy }}
           env:
             {{- range $key, $value := .Values.environment.meta }}
+            {{- if not (and (not $.Values.deployment.db.enabled) $.Values.secret.db.secretRef (or (and (eq $key "DB_HOST") (hasKey (default (dict) $.Values.secret.db.secretRefKey) "host")) (and (eq $key "DB_PORT") (hasKey (default (dict) $.Values.secret.db.secretRefKey) "port")))) }}
             - name: {{ $key }}
               value: {{ $value | quote }}
+            {{- end }}
             {{- end }}
             {{- if .Values.deployment.db.enabled }}
             - name: DB_HOST
               value: {{ include "supabase.db.fullname" . }}
+            {{- else if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "host") }}
+            - name: DB_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "supabase.secret.db.name" . }}
+                  key: {{ include "supabase.secret.db.key.host" . }}
+            {{- end }}
+            {{- if and (not .Values.deployment.db.enabled) .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "port") }}
+            - name: DB_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "supabase.secret.db.name" . }}
+                  key: {{ include "supabase.secret.db.key.port" . }}
             {{- end }}
             - name: DB_PASSWORD
               valueFrom:

--- a/charts/supabase/templates/meta/deployment.yaml
+++ b/charts/supabase/templates/meta/deployment.yaml
@@ -36,7 +36,7 @@ spec:
           imagePullPolicy: {{ .Values.image.meta.pullPolicy }}
           env:
             {{- range $key, $value := .Values.environment.meta }}
-            {{- if not (and (not $.Values.deployment.db.enabled) $.Values.secret.db.secretRef (or (and (eq $key "DB_HOST") (hasKey (default (dict) $.Values.secret.db.secretRefKey) "host")) (and (eq $key "DB_PORT") (hasKey (default (dict) $.Values.secret.db.secretRefKey) "port")))) }}
+            {{- if not (and (not $.Values.deployment.db.enabled) (or (and (eq $key "DB_HOST") (or (and $.Values.secret.db.secretRef (hasKey (default (dict) $.Values.secret.db.secretRefKey) "host")) $.Values.secret.db.host)) (and (eq $key "DB_PORT") (or (and $.Values.secret.db.secretRef (hasKey (default (dict) $.Values.secret.db.secretRefKey) "port")) $.Values.secret.db.port)))) }}
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
@@ -50,6 +50,9 @@ spec:
                 secretKeyRef:
                   name: {{ include "supabase.secret.db.name" . }}
                   key: {{ include "supabase.secret.db.key.host" . }}
+            {{- else if .Values.secret.db.host }}
+            - name: DB_HOST
+              value: {{ .Values.secret.db.host | quote }}
             {{- end }}
             {{- if and (not .Values.deployment.db.enabled) .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "port") }}
             - name: DB_PORT
@@ -57,6 +60,9 @@ spec:
                 secretKeyRef:
                   name: {{ include "supabase.secret.db.name" . }}
                   key: {{ include "supabase.secret.db.key.port" . }}
+            {{- else if and (not .Values.deployment.db.enabled) .Values.secret.db.port }}
+            - name: DB_PORT
+              value: {{ .Values.secret.db.port | quote }}
             {{- end }}
             - name: DB_PASSWORD
               valueFrom:

--- a/charts/supabase/templates/realtime/deployment.yaml
+++ b/charts/supabase/templates/realtime/deployment.yaml
@@ -36,11 +36,23 @@ spec:
             - name: DB_HOST
               {{- if .Values.deployment.db.enabled }}
               value: {{ include "supabase.db.fullname" . | quote }}
+              {{- else if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "host") }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "supabase.secret.db.name" . }}
+                  key: {{ include "supabase.secret.db.key.host" . }}
               {{- else }}
               value: {{ .Values.environment.realtime.DB_HOST | quote }}
               {{- end }}
             - name: DB_PORT
+              {{- if and (not .Values.deployment.db.enabled) .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "port") }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "supabase.secret.db.name" . }}
+                  key: {{ include "supabase.secret.db.key.port" . }}
+              {{- else }}
               value: {{ .Values.environment.realtime.DB_PORT | quote }}
+              {{- end }}
           command: ["/bin/sh", "-c"]
           args:
             - |
@@ -59,12 +71,27 @@ spec:
           args: ["-c", "/app/bin/migrate && /app/bin/realtime eval 'Realtime.Release.seeds(Realtime.Repo)' && /app/bin/server"]
           env:
             {{- range $key, $value := .Values.environment.realtime }}
+            {{- if not (and (not $.Values.deployment.db.enabled) $.Values.secret.db.secretRef (or (and (eq $key "DB_HOST") (hasKey (default (dict) $.Values.secret.db.secretRefKey) "host")) (and (eq $key "DB_PORT") (hasKey (default (dict) $.Values.secret.db.secretRefKey) "port")))) }}
             - name: {{ $key }}
               value: {{ $value | quote }}
+            {{- end }}
             {{- end }}
             {{- if .Values.deployment.db.enabled }}
             - name: DB_HOST
               value: {{ include "supabase.db.fullname" . }}
+            {{- else if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "host") }}
+            - name: DB_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "supabase.secret.db.name" . }}
+                  key: {{ include "supabase.secret.db.key.host" . }}
+            {{- end }}
+            {{- if and (not .Values.deployment.db.enabled) .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "port") }}
+            - name: DB_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "supabase.secret.db.name" . }}
+                  key: {{ include "supabase.secret.db.key.port" . }}
             {{- end }}
             - name: SELF_HOST_TENANT_NAME
               value: {{ include "supabase.realtime.fullname" . }}

--- a/charts/supabase/templates/realtime/deployment.yaml
+++ b/charts/supabase/templates/realtime/deployment.yaml
@@ -101,10 +101,14 @@ spec:
                   name: {{ include "supabase.secret.db.name" . }}
                   key: {{ include "supabase.secret.db.key.password" . }}
             - name: DB_NAME
+              {{- if and .Values.secret.db.secretRef (not (hasKey (default (dict) .Values.secret.db.secretRefKey) "database")) }}
+              value: {{ .Values.secret.db.database | default "postgres" | quote }}
+              {{- else }}
               valueFrom:
                 secretKeyRef:
                   name: {{ include "supabase.secret.db.name" . }}
                   key: {{ include "supabase.secret.db.key.database" . }}
+              {{- end }}
             - name: JWT_SECRET
               valueFrom:
                 secretKeyRef:

--- a/charts/supabase/templates/realtime/deployment.yaml
+++ b/charts/supabase/templates/realtime/deployment.yaml
@@ -41,6 +41,8 @@ spec:
                 secretKeyRef:
                   name: {{ include "supabase.secret.db.name" . }}
                   key: {{ include "supabase.secret.db.key.host" . }}
+              {{- else if .Values.secret.db.host }}
+              value: {{ .Values.secret.db.host | quote }}
               {{- else }}
               value: {{ .Values.environment.realtime.DB_HOST | quote }}
               {{- end }}
@@ -50,6 +52,8 @@ spec:
                 secretKeyRef:
                   name: {{ include "supabase.secret.db.name" . }}
                   key: {{ include "supabase.secret.db.key.port" . }}
+              {{- else if and (not .Values.deployment.db.enabled) .Values.secret.db.port }}
+              value: {{ .Values.secret.db.port | quote }}
               {{- else }}
               value: {{ .Values.environment.realtime.DB_PORT | quote }}
               {{- end }}
@@ -71,7 +75,7 @@ spec:
           args: ["-c", "/app/bin/migrate && /app/bin/realtime eval 'Realtime.Release.seeds(Realtime.Repo)' && /app/bin/server"]
           env:
             {{- range $key, $value := .Values.environment.realtime }}
-            {{- if not (and (not $.Values.deployment.db.enabled) $.Values.secret.db.secretRef (or (and (eq $key "DB_HOST") (hasKey (default (dict) $.Values.secret.db.secretRefKey) "host")) (and (eq $key "DB_PORT") (hasKey (default (dict) $.Values.secret.db.secretRefKey) "port")))) }}
+            {{- if not (and (not $.Values.deployment.db.enabled) (or (and (eq $key "DB_HOST") (or (and $.Values.secret.db.secretRef (hasKey (default (dict) $.Values.secret.db.secretRefKey) "host")) $.Values.secret.db.host)) (and (eq $key "DB_PORT") (or (and $.Values.secret.db.secretRef (hasKey (default (dict) $.Values.secret.db.secretRefKey) "port")) $.Values.secret.db.port)))) }}
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
@@ -85,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: {{ include "supabase.secret.db.name" . }}
                   key: {{ include "supabase.secret.db.key.host" . }}
+            {{- else if .Values.secret.db.host }}
+            - name: DB_HOST
+              value: {{ .Values.secret.db.host | quote }}
             {{- end }}
             {{- if and (not .Values.deployment.db.enabled) .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "port") }}
             - name: DB_PORT
@@ -92,6 +99,9 @@ spec:
                 secretKeyRef:
                   name: {{ include "supabase.secret.db.name" . }}
                   key: {{ include "supabase.secret.db.key.port" . }}
+            {{- else if and (not .Values.deployment.db.enabled) .Values.secret.db.port }}
+            - name: DB_PORT
+              value: {{ .Values.secret.db.port | quote }}
             {{- end }}
             - name: SELF_HOST_TENANT_NAME
               value: {{ include "supabase.realtime.fullname" . }}

--- a/charts/supabase/templates/rest/deployment.yaml
+++ b/charts/supabase/templates/rest/deployment.yaml
@@ -36,11 +36,23 @@ spec:
             - name: DB_HOST
               {{- if .Values.deployment.db.enabled }}
               value: {{ include "supabase.db.fullname" . | quote }}
+              {{- else if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "host") }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "supabase.secret.db.name" . }}
+                  key: {{ include "supabase.secret.db.key.host" . }}
               {{- else }}
               value: {{ .Values.environment.rest.DB_HOST | quote }}
               {{- end }}
             - name: DB_PORT
+              {{- if and (not .Values.deployment.db.enabled) .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "port") }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "supabase.secret.db.name" . }}
+                  key: {{ include "supabase.secret.db.key.port" . }}
+              {{- else }}
               value: {{ .Values.environment.rest.DB_PORT | quote }}
+              {{- end }}
           command: ["/bin/sh", "-c"]
           args:
             - |
@@ -57,12 +69,27 @@ spec:
           imagePullPolicy: {{ .Values.image.rest.pullPolicy }}
           env:
             {{- range $key, $value := .Values.environment.rest }}
+            {{- if not (and (not $.Values.deployment.db.enabled) $.Values.secret.db.secretRef (or (and (eq $key "DB_HOST") (hasKey (default (dict) $.Values.secret.db.secretRefKey) "host")) (and (eq $key "DB_PORT") (hasKey (default (dict) $.Values.secret.db.secretRefKey) "port")))) }}
             - name: {{ $key }}
               value: {{ $value | quote }}
+            {{- end }}
             {{- end }}
             {{- if .Values.deployment.db.enabled }}
             - name: DB_HOST
               value: {{ include "supabase.db.fullname" . }}
+            {{- else if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "host") }}
+            - name: DB_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "supabase.secret.db.name" . }}
+                  key: {{ include "supabase.secret.db.key.host" . }}
+            {{- end }}
+            {{- if and (not .Values.deployment.db.enabled) .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "port") }}
+            - name: DB_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "supabase.secret.db.name" . }}
+                  key: {{ include "supabase.secret.db.key.port" . }}
             {{- end }}
             - name: DB_PASSWORD
               valueFrom:

--- a/charts/supabase/templates/rest/deployment.yaml
+++ b/charts/supabase/templates/rest/deployment.yaml
@@ -102,10 +102,14 @@ spec:
                   name: {{ include "supabase.secret.db.name" . }}
                   key: {{ include "supabase.secret.db.key.passwordEncoded" . }}
             - name: DB_NAME
+              {{- if and .Values.secret.db.secretRef (not (hasKey (default (dict) .Values.secret.db.secretRefKey) "database")) }}
+              value: {{ .Values.secret.db.database | default "postgres" | quote }}
+              {{- else }}
               valueFrom:
                 secretKeyRef:
                   name: {{ include "supabase.secret.db.name" . }}
                   key: {{ include "supabase.secret.db.key.database" . }}
+              {{- end }}
             - name: PGRST_DB_URI
               value: $(DB_DRIVER)://$(DB_USER):$(DB_PASSWORD_ENC)@$(DB_HOST):$(DB_PORT)/$(DB_NAME)?sslmode=$(DB_SSL)
             - name: PGRST_JWT_SECRET

--- a/charts/supabase/templates/rest/deployment.yaml
+++ b/charts/supabase/templates/rest/deployment.yaml
@@ -41,6 +41,8 @@ spec:
                 secretKeyRef:
                   name: {{ include "supabase.secret.db.name" . }}
                   key: {{ include "supabase.secret.db.key.host" . }}
+              {{- else if .Values.secret.db.host }}
+              value: {{ .Values.secret.db.host | quote }}
               {{- else }}
               value: {{ .Values.environment.rest.DB_HOST | quote }}
               {{- end }}
@@ -50,6 +52,8 @@ spec:
                 secretKeyRef:
                   name: {{ include "supabase.secret.db.name" . }}
                   key: {{ include "supabase.secret.db.key.port" . }}
+              {{- else if and (not .Values.deployment.db.enabled) .Values.secret.db.port }}
+              value: {{ .Values.secret.db.port | quote }}
               {{- else }}
               value: {{ .Values.environment.rest.DB_PORT | quote }}
               {{- end }}
@@ -69,7 +73,7 @@ spec:
           imagePullPolicy: {{ .Values.image.rest.pullPolicy }}
           env:
             {{- range $key, $value := .Values.environment.rest }}
-            {{- if not (and (not $.Values.deployment.db.enabled) $.Values.secret.db.secretRef (or (and (eq $key "DB_HOST") (hasKey (default (dict) $.Values.secret.db.secretRefKey) "host")) (and (eq $key "DB_PORT") (hasKey (default (dict) $.Values.secret.db.secretRefKey) "port")))) }}
+            {{- if not (and (not $.Values.deployment.db.enabled) (or (and (eq $key "DB_HOST") (or (and $.Values.secret.db.secretRef (hasKey (default (dict) $.Values.secret.db.secretRefKey) "host")) $.Values.secret.db.host)) (and (eq $key "DB_PORT") (or (and $.Values.secret.db.secretRef (hasKey (default (dict) $.Values.secret.db.secretRefKey) "port")) $.Values.secret.db.port)))) }}
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
@@ -83,6 +87,9 @@ spec:
                 secretKeyRef:
                   name: {{ include "supabase.secret.db.name" . }}
                   key: {{ include "supabase.secret.db.key.host" . }}
+            {{- else if .Values.secret.db.host }}
+            - name: DB_HOST
+              value: {{ .Values.secret.db.host | quote }}
             {{- end }}
             {{- if and (not .Values.deployment.db.enabled) .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "port") }}
             - name: DB_PORT
@@ -90,6 +97,9 @@ spec:
                 secretKeyRef:
                   name: {{ include "supabase.secret.db.name" . }}
                   key: {{ include "supabase.secret.db.key.port" . }}
+            {{- else if and (not .Values.deployment.db.enabled) .Values.secret.db.port }}
+            - name: DB_PORT
+              value: {{ .Values.secret.db.port | quote }}
             {{- end }}
             - name: DB_PASSWORD
               valueFrom:

--- a/charts/supabase/templates/secret/db.yaml
+++ b/charts/supabase/templates/secret/db.yaml
@@ -6,6 +6,14 @@
 {{- end -}}
 {{- end -}}
 
+{{- define "supabase.secret.db.key.host" -}}
+{{- index (default (dict) .Values.secret.db.secretRefKey) "host" | default "host" -}}
+{{- end -}}
+
+{{- define "supabase.secret.db.key.port" -}}
+{{- index (default (dict) .Values.secret.db.secretRefKey) "port" | default "port" -}}
+{{- end -}}
+
 {{- define "supabase.secret.db.key.password" -}}
 {{- index (default (dict) .Values.secret.db.secretRefKey) "password" | default "password" -}}
 {{- end -}}

--- a/charts/supabase/templates/storage/deployment.yaml
+++ b/charts/supabase/templates/storage/deployment.yaml
@@ -37,11 +37,23 @@ spec:
             - name: DB_HOST
               {{- if .Values.deployment.db.enabled }}
               value: {{ include "supabase.db.fullname" . | quote }}
+              {{- else if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "host") }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "supabase.secret.db.name" . }}
+                  key: {{ include "supabase.secret.db.key.host" . }}
               {{- else }}
               value: {{ .Values.environment.storage.DB_HOST | quote }}
               {{- end }}
             - name: DB_PORT
+              {{- if and (not .Values.deployment.db.enabled) .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "port") }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "supabase.secret.db.name" . }}
+                  key: {{ include "supabase.secret.db.key.port" . }}
+              {{- else }}
               value: {{ .Values.environment.storage.DB_PORT | quote }}
+              {{- end }}
           command: ["/bin/sh", "-c"]
           args:
             - |
@@ -93,7 +105,7 @@ spec:
           imagePullPolicy: {{ .Values.image.storage.pullPolicy }}
           env:
             {{- range $key, $value := .Values.environment.storage }}
-            {{- if and (ne $key "AWS_ACCESS_KEY_ID") (ne $key "AWS_SECRET_ACCESS_KEY") (ne $key "STORAGE_BACKEND") }}
+            {{- if and (ne $key "AWS_ACCESS_KEY_ID") (ne $key "AWS_SECRET_ACCESS_KEY") (ne $key "STORAGE_BACKEND") (not (and (not $.Values.deployment.db.enabled) $.Values.secret.db.secretRef (or (and (eq $key "DB_HOST") (hasKey (default (dict) $.Values.secret.db.secretRefKey) "host")) (and (eq $key "DB_PORT") (hasKey (default (dict) $.Values.secret.db.secretRefKey) "port"))))) }}
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
@@ -136,6 +148,19 @@ spec:
             {{- if .Values.deployment.db.enabled }}
             - name: DB_HOST
               value: {{ include "supabase.db.fullname" . }}
+            {{- else if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "host") }}
+            - name: DB_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "supabase.secret.db.name" . }}
+                  key: {{ include "supabase.secret.db.key.host" . }}
+            {{- end }}
+            {{- if and (not .Values.deployment.db.enabled) .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "port") }}
+            - name: DB_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "supabase.secret.db.name" . }}
+                  key: {{ include "supabase.secret.db.key.port" . }}
             {{- end }}
             {{- if .Values.deployment.rest.enabled }}
             - name: POSTGREST_URL

--- a/charts/supabase/templates/storage/deployment.yaml
+++ b/charts/supabase/templates/storage/deployment.yaml
@@ -42,6 +42,8 @@ spec:
                 secretKeyRef:
                   name: {{ include "supabase.secret.db.name" . }}
                   key: {{ include "supabase.secret.db.key.host" . }}
+              {{- else if .Values.secret.db.host }}
+              value: {{ .Values.secret.db.host | quote }}
               {{- else }}
               value: {{ .Values.environment.storage.DB_HOST | quote }}
               {{- end }}
@@ -51,6 +53,8 @@ spec:
                 secretKeyRef:
                   name: {{ include "supabase.secret.db.name" . }}
                   key: {{ include "supabase.secret.db.key.port" . }}
+              {{- else if and (not .Values.deployment.db.enabled) .Values.secret.db.port }}
+              value: {{ .Values.secret.db.port | quote }}
               {{- else }}
               value: {{ .Values.environment.storage.DB_PORT | quote }}
               {{- end }}
@@ -105,7 +109,7 @@ spec:
           imagePullPolicy: {{ .Values.image.storage.pullPolicy }}
           env:
             {{- range $key, $value := .Values.environment.storage }}
-            {{- if and (ne $key "AWS_ACCESS_KEY_ID") (ne $key "AWS_SECRET_ACCESS_KEY") (ne $key "STORAGE_BACKEND") (not (and (not $.Values.deployment.db.enabled) $.Values.secret.db.secretRef (or (and (eq $key "DB_HOST") (hasKey (default (dict) $.Values.secret.db.secretRefKey) "host")) (and (eq $key "DB_PORT") (hasKey (default (dict) $.Values.secret.db.secretRefKey) "port"))))) }}
+            {{- if and (ne $key "AWS_ACCESS_KEY_ID") (ne $key "AWS_SECRET_ACCESS_KEY") (ne $key "STORAGE_BACKEND") (not (and (not $.Values.deployment.db.enabled) (or (and (eq $key "DB_HOST") (or (and $.Values.secret.db.secretRef (hasKey (default (dict) $.Values.secret.db.secretRefKey) "host")) $.Values.secret.db.host)) (and (eq $key "DB_PORT") (or (and $.Values.secret.db.secretRef (hasKey (default (dict) $.Values.secret.db.secretRefKey) "port")) $.Values.secret.db.port))))) }}
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
@@ -154,6 +158,9 @@ spec:
                 secretKeyRef:
                   name: {{ include "supabase.secret.db.name" . }}
                   key: {{ include "supabase.secret.db.key.host" . }}
+            {{- else if .Values.secret.db.host }}
+            - name: DB_HOST
+              value: {{ .Values.secret.db.host | quote }}
             {{- end }}
             {{- if and (not .Values.deployment.db.enabled) .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "port") }}
             - name: DB_PORT
@@ -161,6 +168,9 @@ spec:
                 secretKeyRef:
                   name: {{ include "supabase.secret.db.name" . }}
                   key: {{ include "supabase.secret.db.key.port" . }}
+            {{- else if and (not .Values.deployment.db.enabled) .Values.secret.db.port }}
+            - name: DB_PORT
+              value: {{ .Values.secret.db.port | quote }}
             {{- end }}
             {{- if .Values.deployment.rest.enabled }}
             - name: POSTGREST_URL

--- a/charts/supabase/templates/storage/deployment.yaml
+++ b/charts/supabase/templates/storage/deployment.yaml
@@ -177,10 +177,14 @@ spec:
                   name: {{ include "supabase.secret.db.name" . }}
                   key: {{ include "supabase.secret.db.key.passwordEncoded" . }}
             - name: DB_NAME
+              {{- if and .Values.secret.db.secretRef (not (hasKey (default (dict) .Values.secret.db.secretRefKey) "database")) }}
+              value: {{ .Values.secret.db.database | default "postgres" | quote }}
+              {{- else }}
               valueFrom:
                 secretKeyRef:
                   name: {{ include "supabase.secret.db.name" . }}
                   key: {{ include "supabase.secret.db.key.database" . }}
+              {{- end }}
             - name: DATABASE_URL
               value: $(DB_DRIVER)://$(DB_USER):$(DB_PASSWORD_ENC)@$(DB_HOST):$(DB_PORT)/$(DB_NAME)?search_path=auth&sslmode=$(DB_SSL)
             - name: PGRST_JWT_SECRET

--- a/charts/supabase/templates/studio/deployment.yaml
+++ b/charts/supabase/templates/studio/deployment.yaml
@@ -54,10 +54,14 @@ spec:
             {{- end }}
 
             - name: POSTGRES_DB
+              {{- if and .Values.secret.db.secretRef (not (hasKey (default (dict) .Values.secret.db.secretRefKey) "database")) }}
+              value: {{ .Values.secret.db.database | default "postgres" | quote }}
+              {{- else }}
               valueFrom:
                 secretKeyRef:
                   name: {{ include "supabase.secret.db.name" . }}
                   key: {{ include "supabase.secret.db.key.database" . }}
+              {{- end }}
 
             - name: POSTGRES_PASSWORD
               valueFrom:

--- a/charts/supabase/values.yaml
+++ b/charts/supabase/values.yaml
@@ -93,6 +93,8 @@ secret:
 
     ## Map to actual keys inside secretRef if they differ
     # secretRefKey:
+    #   host: host
+    #   port: port
     #   password: password
     #   database: database
 

--- a/charts/supabase/values.yaml
+++ b/charts/supabase/values.yaml
@@ -88,6 +88,12 @@ secret:
     password: "your-super-secret-and-long-postgres-password"
     database: "postgres"
 
+    ## External database host/port (used when deployment.db.enabled is false).
+    ## Leave empty to fall back to environment.<service>.DB_HOST / DB_PORT.
+    ## Ignored when deployment.db.enabled is true (internal DB service is used).
+    host: ""
+    port: ""
+
     ## Reference to existing secret
     # secretRef: ""
 


### PR DESCRIPTION
## Summary

Two changes that together enable full external database support without running the internal Supabase postgres StatefulSet.

### 1. Support secretRefKey for DB host and port

When using an external database (deployment.db.enabled: false) with secret.db.secretRef, users can now map host and port from the referenced secret via secretRefKey.host and secretRefKey.port.

This allows DB_HOST and DB_PORT to be sourced from a Kubernetes secret (e.g. provisioned by Crossplane, Terraform, or an operator) rather than requiring hardcoded values in environment config.

**Example:**

```yaml
secret:
  db:
    database: mydb
    secretRef: my-crossplane-db-conn
    secretRefKey:
      host: host
      port: port
      password: password
```

**Changed templates:** auth, rest, storage, realtime, meta, analytics (init containers + main containers). The range loop now skips DB_HOST/DB_PORT when they come from secretRefKey to prevent duplicate env entries.

**Backwards compatible:** When host/port are not in secretRefKey, existing behavior is preserved.

### 2. External database init Job

When deployment.db.enabled is false, the chart now creates a post-install hook Job that bootstraps the required Supabase roles, schemas, and extensions on the external database.

Previously, disabling the internal database also skipped all init scripts, leaving external databases without the roles that services depend on (supabase_auth_admin, supabase_storage_admin, authenticator, anon, authenticated, service_role, etc). This caused CrashLoopBackOff on auth, realtime, storage, rest, and meta deployments (see #86).

**New templates:**
- `init-external-config.yaml` — ConfigMap with idempotent init SQL sourced from [supabase/postgres init-scripts](https://github.com/supabase/postgres/tree/develop/migrations/db/init-scripts)
- `init-external-job.yaml` — Helm post-install hook Job that runs the init SQL against the external DB

All statements use IF NOT EXISTS / CREATE OR REPLACE so re-runs are safe.

## Testing

Verified via helm template that:
- External DB with secretRefKey host/port renders valueFrom secretKeyRef (no duplicates)
- External DB without host in secretRefKey falls back to environment.*.DB_HOST
- Internal DB enabled has unchanged behavior, no external init Job rendered
- Init Job + ConfigMap only render when deployment.db.enabled is false

Closes #86