### PR TITLE
refactor(chart): move inline env sections to named Helm defines for readability

### DIFF
--- a/charts/supabase/templates/analytics/deployment.yaml
+++ b/charts/supabase/templates/analytics/deployment.yaml
@@ -33,32 +33,7 @@ spec:
           image: "{{ .Values.image.initDb.repository }}:{{ .Values.image.initDb.tag }}"
           imagePullPolicy: {{ .Values.image.initDb.pullPolicy }}
           env:
-            - name: DB_HOST
-              {{- if .Values.deployment.db.enabled }}
-              value: {{ include "supabase.db.fullname" . | quote }}
-              {{- else if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "host") }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.host" . }}
-              {{- else if .Values.secret.db.host }}
-              value: {{ .Values.secret.db.host | quote }}
-              {{- else }}
-              value: {{ .Values.environment.analytics.DB_HOST | quote }}
-              {{- end }}
-            - name: DB_USER
-              value: $(DB_USERNAME)
-            - name: DB_PORT
-              {{- if and (not .Values.deployment.db.enabled) .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "port") }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.port" . }}
-              {{- else if and (not .Values.deployment.db.enabled) .Values.secret.db.port }}
-              value: {{ .Values.secret.db.port | quote }}
-              {{- else }}
-              value: {{ .Values.environment.analytics.DB_PORT | quote }}
-              {{- end }}
+            {{- include "supabase.analytics.initDbEnv" . | nindent 12 }}
           command: ["/bin/sh", "-c"]
           args:
             - |
@@ -74,54 +49,7 @@ spec:
           image: "{{ .Values.image.analytics.repository }}:{{ .Values.image.analytics.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.analytics.pullPolicy }}
           env:
-            {{- range $key, $value := .Values.environment.analytics }}
-            {{- if not (and (not $.Values.deployment.db.enabled) (or (and (eq $key "DB_HOST") (or (and $.Values.secret.db.secretRef (hasKey (default (dict) $.Values.secret.db.secretRefKey) "host")) $.Values.secret.db.host)) (and (eq $key "DB_PORT") (or (and $.Values.secret.db.secretRef (hasKey (default (dict) $.Values.secret.db.secretRefKey) "port")) $.Values.secret.db.port)))) }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
-            {{- end }}
-            {{- end }}
-            - name: DB_HOSTNAME
-              {{- if .Values.deployment.db.enabled }}
-              value: {{ include "supabase.db.fullname" . | quote }}
-              {{- else if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "host") }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.host" . }}
-              {{- else if .Values.secret.db.host }}
-              value: {{ .Values.secret.db.host | quote }}
-              {{- else }}
-              value: {{ .Values.environment.analytics.DB_HOST | quote }}
-              {{- end }}
-            - name: DB_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.password" . }}
-            - name: DB_PASSWORD_ENC
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.passwordEncoded" . }}
-            - name:  LOGFLARE_PUBLIC_ACCESS_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.analytics.name" . }}
-                  key: {{ include "supabase.secret.analytics.key.publicAccessToken" . }}
-            - name: LOGFLARE_PRIVATE_ACCESS_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.analytics.name" . }}
-                  key: {{ include "supabase.secret.analytics.key.privateAccessToken" . }}
-            {{- if .Values.bigQuery.enabled }}
-            - name: GOOGLE_PROJECT_ID
-              value: {{ .Values.bigQuery.projectId | quote }}
-            - name: GOOGLE_PROJECT_NUMBER
-              value: {{ .Values.bigQuery.projectNumber | quote }}
-            {{- else }}
-            - name: POSTGRES_BACKEND_URL
-              value: $(DB_DRIVER)://$(DB_USERNAME):$(DB_PASSWORD_ENC)@$(DB_HOSTNAME):$(DB_PORT)/$(DB_DATABASE)
-            {{- end }}
+            {{- include "supabase.analytics.env" . | nindent 12 }}
           {{- with .Values.deployment.analytics.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}
@@ -172,3 +100,87 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}
+
+--- 
+
+{{- define "supabase.analytics.initDbEnv" -}}
+- name: DB_HOST
+  {{- if .Values.deployment.db.enabled }}
+  value: {{ include "supabase.db.fullname" . | quote }}
+  {{- else if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "host") }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.db.name" . }}
+      key: {{ include "supabase.secret.db.key.host" . }}
+  {{- else if .Values.secret.db.host }}
+  value: {{ .Values.secret.db.host | quote }}
+  {{- else }}
+  value: {{ .Values.environment.analytics.DB_HOST | quote }}
+  {{- end }}
+- name: DB_USER
+  value: $(DB_USERNAME)
+- name: DB_PORT
+  {{- if and (not .Values.deployment.db.enabled) .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "port") }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.db.name" . }}
+      key: {{ include "supabase.secret.db.key.port" . }}
+  {{- else if and (not .Values.deployment.db.enabled) .Values.secret.db.port }}
+  value: {{ .Values.secret.db.port | quote }}
+  {{- else }}
+  value: {{ .Values.environment.analytics.DB_PORT | quote }}
+  {{- end }}
+{{- end -}}
+
+---
+
+{{- define "supabase.analytics.env" -}}
+{{- range $key, $value := .Values.environment.analytics }}
+{{- if not (and (not $.Values.deployment.db.enabled) (or (and (eq $key "DB_HOST") (or (and $.Values.secret.db.secretRef (hasKey (default (dict) $.Values.secret.db.secretRefKey) "host")) $.Values.secret.db.host)) (and (eq $key "DB_PORT") (or (and $.Values.secret.db.secretRef (hasKey (default (dict) $.Values.secret.db.secretRefKey) "port")) $.Values.secret.db.port)))) }}
+- name: {{ $key }}
+  value: {{ $value | quote }}
+{{- end }}
+{{- end }}
+- name: DB_HOSTNAME
+  {{- if .Values.deployment.db.enabled }}
+  value: {{ include "supabase.db.fullname" . | quote }}
+  {{- else if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "host") }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.db.name" . }}
+      key: {{ include "supabase.secret.db.key.host" . }}
+  {{- else if .Values.secret.db.host }}
+  value: {{ .Values.secret.db.host | quote }}
+  {{- else }}
+  value: {{ .Values.environment.analytics.DB_HOST | quote }}
+  {{- end }}
+- name: DB_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.db.name" . }}
+      key: {{ include "supabase.secret.db.key.password" . }}
+- name: DB_PASSWORD_ENC
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.db.name" . }}
+      key: {{ include "supabase.secret.db.key.passwordEncoded" . }}
+- name:  LOGFLARE_PUBLIC_ACCESS_TOKEN
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.analytics.name" . }}
+      key: {{ include "supabase.secret.analytics.key.publicAccessToken" . }}
+- name: LOGFLARE_PRIVATE_ACCESS_TOKEN
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.analytics.name" . }}
+      key: {{ include "supabase.secret.analytics.key.privateAccessToken" . }}
+{{- if .Values.bigQuery.enabled }}
+- name: GOOGLE_PROJECT_ID
+  value: {{ .Values.bigQuery.projectId | quote }}
+- name: GOOGLE_PROJECT_NUMBER
+  value: {{ .Values.bigQuery.projectNumber | quote }}
+{{- else }}
+- name: POSTGRES_BACKEND_URL
+  value: $(DB_DRIVER)://$(DB_USERNAME):$(DB_PASSWORD_ENC)@$(DB_HOSTNAME):$(DB_PORT)/$(DB_DATABASE)
+{{- end }}
+{{- end -}}

--- a/charts/supabase/templates/auth/deployment.yaml
+++ b/charts/supabase/templates/auth/deployment.yaml
@@ -33,30 +33,7 @@ spec:
           image: "{{ .Values.image.initDb.repository }}:{{ .Values.image.initDb.tag }}"
           imagePullPolicy: {{ .Values.image.initDb.pullPolicy }}
           env:
-            - name: DB_HOST
-              {{- if .Values.deployment.db.enabled }}
-              value: {{ include "supabase.db.fullname" . | quote }}
-              {{- else if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "host") }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.host" . }}
-              {{- else if .Values.secret.db.host }}
-              value: {{ .Values.secret.db.host | quote }}
-              {{- else }}
-              value: {{ .Values.environment.auth.DB_HOST | quote }}
-              {{- end }}
-            - name: DB_PORT
-              {{- if and (not .Values.deployment.db.enabled) .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "port") }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.port" . }}
-              {{- else if and (not .Values.deployment.db.enabled) .Values.secret.db.port }}
-              value: {{ .Values.secret.db.port | quote }}
-              {{- else }}
-              value: {{ .Values.environment.auth.DB_PORT | quote }}
-              {{- end }}
+            {{- include "supabase.auth.initDbEnv" . | nindent 12 }}
           command: ["/bin/sh", "-c"]
           args:
             - |
@@ -72,80 +49,7 @@ spec:
           image: "{{ .Values.image.auth.repository }}:{{ .Values.image.auth.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.auth.pullPolicy }}
           env:
-            {{- range $key, $value := .Values.environment.auth }}
-            {{- if not (and (not $.Values.deployment.db.enabled) (or (and (eq $key "DB_HOST") (or (and $.Values.secret.db.secretRef (hasKey (default (dict) $.Values.secret.db.secretRefKey) "host")) $.Values.secret.db.host)) (and (eq $key "DB_PORT") (or (and $.Values.secret.db.secretRef (hasKey (default (dict) $.Values.secret.db.secretRefKey) "port")) $.Values.secret.db.port)))) }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
-            {{- end }}
-            {{- end }}
-            {{- if .Values.deployment.db.enabled }}
-            - name: DB_HOST
-              value: {{ include "supabase.db.fullname" . }}
-            {{- else if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "host") }}
-            - name: DB_HOST
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.host" . }}
-            {{- else if .Values.secret.db.host }}
-            - name: DB_HOST
-              value: {{ .Values.secret.db.host | quote }}
-            {{- end }}
-            {{- if and (not .Values.deployment.db.enabled) .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "port") }}
-            - name: DB_PORT
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.port" . }}
-            {{- else if and (not .Values.deployment.db.enabled) .Values.secret.db.port }}
-            - name: DB_PORT
-              value: {{ .Values.secret.db.port | quote }}
-            {{- end }}
-            - name: DB_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.password" . }}
-            - name: DB_PASSWORD_ENC
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.passwordEncoded" . }}
-            - name: DB_NAME
-              {{- if and .Values.secret.db.secretRef (not (hasKey (default (dict) .Values.secret.db.secretRefKey) "database")) }}
-              value: {{ .Values.secret.db.database | default "postgres" | quote }}
-              {{- else }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.database" . }}
-              {{- end }}
-            - name: GOTRUE_DB_DATABASE_URL
-              value: $(DB_DRIVER)://$(DB_USER):$(DB_PASSWORD_ENC)@$(DB_HOST):$(DB_PORT)/$(DB_NAME)?sslmode=$(DB_SSL)
-            - name: GOTRUE_DB_DRIVER
-              value: $(DB_DRIVER)
-            - name: GOTRUE_JWT_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.jwt.name" . }}
-                  key: {{ include "supabase.secret.jwt.key.secret" . }}
-            {{- if or .Values.secret.apikey.secretRef .Values.secret.apikey.jwtKeys }}
-            - name: GOTRUE_JWT_KEYS
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.apikey.name" . }}
-                  key: {{ include "supabase.secret.apikey.key.jwtKeys" . }}
-            {{- end }}
-            - name: GOTRUE_SMTP_USER
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.smtp.name" . }}
-                  key: {{ include "supabase.secret.smtp.key.username" . }}
-            - name: GOTRUE_SMTP_PASS
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.smtp.name" . }}
-                  key: {{ include "supabase.secret.smtp.key.password" . }}
+            {{- include "supabase.auth.env" . | nindent 12 }}
           {{- with .Values.deployment.auth.envFrom }}
           envFrom:
             {{- toYaml . | nindent 12 }}
@@ -187,3 +91,111 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}
+
+---
+
+{{- define "supabase.auth.initDbEnv" -}}
+- name: DB_HOST
+  {{- if .Values.deployment.db.enabled }}
+  value: {{ include "supabase.db.fullname" . | quote }}
+  {{- else if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "host") }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.db.name" . }}
+      key: {{ include "supabase.secret.db.key.host" . }}
+  {{- else if .Values.secret.db.host }}
+  value: {{ .Values.secret.db.host | quote }}
+  {{- else }}
+  value: {{ .Values.environment.auth.DB_HOST | quote }}
+  {{- end }}
+- name: DB_PORT
+  {{- if and (not .Values.deployment.db.enabled) .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "port") }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.db.name" . }}
+      key: {{ include "supabase.secret.db.key.port" . }}
+  {{- else if and (not .Values.deployment.db.enabled) .Values.secret.db.port }}
+  value: {{ .Values.secret.db.port | quote }}
+  {{- else }}
+  value: {{ .Values.environment.auth.DB_PORT | quote }}
+  {{- end }}
+{{- end -}}
+
+---
+
+{{- define "supabase.auth.env" -}}
+{{- range $key, $value := .Values.environment.auth }}
+{{- if not (and (not $.Values.deployment.db.enabled) (or (and (eq $key "DB_HOST") (or (and $.Values.secret.db.secretRef (hasKey (default (dict) $.Values.secret.db.secretRefKey) "host")) $.Values.secret.db.host)) (and (eq $key "DB_PORT") (or (and $.Values.secret.db.secretRef (hasKey (default (dict) $.Values.secret.db.secretRefKey) "port")) $.Values.secret.db.port)))) }}
+- name: {{ $key }}
+  value: {{ $value | quote }}
+{{- end }}
+{{- end }}
+{{- if .Values.deployment.db.enabled }}
+- name: DB_HOST
+  value: {{ include "supabase.db.fullname" . }}
+{{- else if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "host") }}
+- name: DB_HOST
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.db.name" . }}
+      key: {{ include "supabase.secret.db.key.host" . }}
+{{- else if .Values.secret.db.host }}
+- name: DB_HOST
+  value: {{ .Values.secret.db.host | quote }}
+{{- end }}
+{{- if and (not .Values.deployment.db.enabled) .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "port") }}
+- name: DB_PORT
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.db.name" . }}
+      key: {{ include "supabase.secret.db.key.port" . }}
+{{- else if and (not .Values.deployment.db.enabled) .Values.secret.db.port }}
+- name: DB_PORT
+  value: {{ .Values.secret.db.port | quote }}
+{{- end }}
+- name: DB_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.db.name" . }}
+      key: {{ include "supabase.secret.db.key.password" . }}
+- name: DB_PASSWORD_ENC
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.db.name" . }}
+      key: {{ include "supabase.secret.db.key.passwordEncoded" . }}
+- name: DB_NAME
+  {{- if and .Values.secret.db.secretRef (not (hasKey (default (dict) .Values.secret.db.secretRefKey) "database")) }}
+  value: {{ .Values.secret.db.database | default "postgres" | quote }}
+  {{- else }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.db.name" . }}
+      key: {{ include "supabase.secret.db.key.database" . }}
+  {{- end }}
+- name: GOTRUE_DB_DATABASE_URL
+  value: $(DB_DRIVER)://$(DB_USER):$(DB_PASSWORD_ENC)@$(DB_HOST):$(DB_PORT)/$(DB_NAME)?sslmode=$(DB_SSL)
+- name: GOTRUE_DB_DRIVER
+  value: $(DB_DRIVER)
+- name: GOTRUE_JWT_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.jwt.name" . }}
+      key: {{ include "supabase.secret.jwt.key.secret" . }}
+{{- if or .Values.secret.apikey.secretRef .Values.secret.apikey.jwtKeys }}
+- name: GOTRUE_JWT_KEYS
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.apikey.name" . }}
+      key: {{ include "supabase.secret.apikey.key.jwtKeys" . }}
+{{- end }}
+- name: GOTRUE_SMTP_USER
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.smtp.name" . }}
+      key: {{ include "supabase.secret.smtp.key.username" . }}
+- name: GOTRUE_SMTP_PASS
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.smtp.name" . }}
+      key: {{ include "supabase.secret.smtp.key.password" . }}
+{{- end -}}

--- a/charts/supabase/templates/db/init-external-job.yaml
+++ b/charts/supabase/templates/db/init-external-job.yaml
@@ -56,53 +56,7 @@ spec:
 
               echo "=== External database initialization complete ==="
           env:
-            - name: DB_HOST
-              {{- if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "host") }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.host" . }}
-              {{- else if .Values.secret.db.host }}
-              value: {{ .Values.secret.db.host | quote }}
-              {{- else }}
-              value: {{ .Values.environment.auth.DB_HOST | default "" | quote }}
-              {{- end }}
-            - name: DB_PORT
-              {{- if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "port") }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.port" . }}
-              {{- else if .Values.secret.db.port }}
-              value: {{ .Values.secret.db.port | quote }}
-              {{- else }}
-              value: {{ .Values.environment.auth.DB_PORT | default "5432" | quote }}
-              {{- end }}
-            - name: DB_USER
-              {{- if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "username") }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ index (default (dict) .Values.secret.db.secretRefKey) "username" }}
-              {{- else }}
-              value: "postgres"
-              {{- end }}
-            - name: DB_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.password" . }}
-            - name: DB_NAME
-              {{- if and .Values.secret.db.secretRef (not (hasKey (default (dict) .Values.secret.db.secretRefKey) "database")) }}
-              value: {{ .Values.secret.db.database | default "postgres" | quote }}
-              {{- else }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.database" . }}
-              {{- end }}
-            - name: DB_SSL
-              value: {{ .Values.environment.auth.DB_SSL | default "prefer" | quote }}
+            {{- include "supabase.db.initExternalEnv" . | nindent 12 }}
           volumeMounts:
             - name: init-scripts
               mountPath: /init-scripts
@@ -112,3 +66,53 @@ spec:
           configMap:
             name: {{ include "supabase.fullname" . }}-db-init-external
 {{- end }}
+
+{{- define "supabase.db.initExternalEnv" -}}
+- name: DB_HOST
+  {{- if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "host") }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.db.name" . }}
+      key: {{ include "supabase.secret.db.key.host" . }}
+  {{- else if .Values.secret.db.host }}
+  value: {{ .Values.secret.db.host | quote }}
+  {{- else }}
+  value: {{ .Values.environment.auth.DB_HOST | default "" | quote }}
+  {{- end }}
+- name: DB_PORT
+  {{- if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "port") }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.db.name" . }}
+      key: {{ include "supabase.secret.db.key.port" . }}
+  {{- else if .Values.secret.db.port }}
+  value: {{ .Values.secret.db.port | quote }}
+  {{- else }}
+  value: {{ .Values.environment.auth.DB_PORT | default "5432" | quote }}
+  {{- end }}
+- name: DB_USER
+  {{- if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "username") }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.db.name" . }}
+      key: {{ index (default (dict) .Values.secret.db.secretRefKey) "username" }}
+  {{- else }}
+  value: "postgres"
+  {{- end }}
+- name: DB_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.db.name" . }}
+      key: {{ include "supabase.secret.db.key.password" . }}
+- name: DB_NAME
+  {{- if and .Values.secret.db.secretRef (not (hasKey (default (dict) .Values.secret.db.secretRefKey) "database")) }}
+  value: {{ .Values.secret.db.database | default "postgres" | quote }}
+  {{- else }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.db.name" . }}
+      key: {{ include "supabase.secret.db.key.database" . }}
+  {{- end }}
+- name: DB_SSL
+  value: {{ .Values.environment.auth.DB_SSL | default "prefer" | quote }}
+{{- end -}}

--- a/charts/supabase/templates/db/statefulset.yaml
+++ b/charts/supabase/templates/db/statefulset.yaml
@@ -70,35 +70,7 @@ spec:
               exec:
                 command: ["/bin/sh", "-c", "pg_ctl -D /var/lib/postgres/data -w -t 60 -m fast stop"]
           env:
-            {{- range $key, $value := .Values.environment.db }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
-            {{- end }}
-            - name: PGPASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.password" . }}
-            - name: POSTGRES_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.password" . }}
-            - name: PGDATABASE
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.database" . }}
-            - name: POSTGRES_DB
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.database" . }}
-            - name: JWT_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.jwt.name" . }}
-                  key: {{ include "supabase.secret.jwt.key.secret" . }}
+            {{- include "supabase.db.env" . | nindent 12 }}
           {{- with .Values.deployment.db.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}
@@ -157,3 +129,44 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}
+
+---
+
+{{- define "supabase.db.env" -}}
+
+{{- range $key, $value := .Values.environment.db }}
+- name: {{ $key }}
+  value: {{ $value | quote }}
+{{- end }}
+
+- name: PGPASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.db.name" . }}
+      key: {{ include "supabase.secret.db.key.password" . }}
+      
+- name: POSTGRES_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.db.name" . }}
+      key: {{ include "supabase.secret.db.key.password" . }}
+      
+- name: PGDATABASE
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.db.name" . }}
+      key: {{ include "supabase.secret.db.key.database" . }}
+      
+- name: POSTGRES_DB
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.db.name" . }}
+      key: {{ include "supabase.secret.db.key.database" . }}
+      
+- name: JWT_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.jwt.name" . }}
+      key: {{ include "supabase.secret.jwt.key.secret" . }}
+      
+{{- end -}}

--- a/charts/supabase/templates/functions/deployment.yaml
+++ b/charts/supabase/templates/functions/deployment.yaml
@@ -43,72 +43,7 @@ spec:
             {{- toYaml .Values.deployment.functions.envFrom | nindent 12 }}
           {{- end }}
           env:
-            {{- range $key, $value := .Values.environment.functions }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
-            {{- end }}
-
-            {{- if .Values.deployment.kong.enabled }}
-            - name: SUPABASE_URL
-              value: http://{{ include "supabase.kong.fullname" . }}:{{ .Values.service.kong.port }}
-            {{- end }}
-
-            - name: DB_HOSTNAME
-              {{- if .Values.deployment.db.enabled }}
-              value: {{ include "supabase.db.fullname" . }}
-              {{- else }}
-              value: $(DB_HOST)
-              {{- end }}
-            - name: DB_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.password" . }}
-            - name: DB_PASSWORD_ENC
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.passwordEncoded" . }}
-            - name: DB_DATABASE
-              {{- if and .Values.secret.db.secretRef (not (hasKey (default (dict) .Values.secret.db.secretRefKey) "database")) }}
-              value: {{ .Values.secret.db.database | default "postgres" | quote }}
-              {{- else }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.database" . }}
-              {{- end }}
-            - name: JWT_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.jwt.name" . }}
-                  key: {{ include "supabase.secret.jwt.key.secret" . }}
-            - name: SUPABASE_ANON_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.jwt.name" . }}
-                  key: {{ include "supabase.secret.jwt.key.anonKey" . }}
-            - name: SUPABASE_SERVICE_ROLE_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.jwt.name" . }}
-                  key: {{ include "supabase.secret.jwt.key.serviceKey" . }}
-            - name: SUPABASE_PUBLISHABLE_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.apikey.name" . }}
-                  key: {{ include "supabase.secret.apikey.key.publishableKey" . }}
-            - name: SUPABASE_SECRET_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.apikey.name" . }}
-                  key: {{ include "supabase.secret.apikey.key.secretKey" . }}
-            - name: SUPABASE_PUBLISHABLE_KEYS
-              value: '{"default":"$(SUPABASE_PUBLISHABLE_KEY)"}'
-            - name: SUPABASE_SECRET_KEYS
-              value: '{"default":"$(SUPABASE_SECRET_KEY)"}'
-            - name: SUPABASE_DB_URL
-              value: $(DB_DRIVER)://$(DB_USERNAME):$(DB_PASSWORD_ENC)@$(DB_HOSTNAME):$(DB_PORT)/$(DB_DATABASE)?search_path=auth&sslmode=$(DB_SSL)
+            {{- include "supabase.functions.env" . | nindent 12 }}
           {{- with .Values.deployment.functions.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}
@@ -166,3 +101,74 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}
+
+---
+
+{{- define "supabase.functions.env" -}}
+{{- range $key, $value := .Values.environment.functions }}
+- name: {{ $key }}
+  value: {{ $value | quote }}
+{{- end }}
+
+{{- if .Values.deployment.kong.enabled }}
+- name: SUPABASE_URL
+  value: http://{{ include "supabase.kong.fullname" . }}:{{ .Values.service.kong.port }}
+{{- end }}
+
+- name: DB_HOSTNAME
+  {{- if .Values.deployment.db.enabled }}
+  value: {{ include "supabase.db.fullname" . }}
+  {{- else }}
+  value: $(DB_HOST)
+  {{- end }}
+- name: DB_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.db.name" . }}
+      key: {{ include "supabase.secret.db.key.password" . }}
+- name: DB_PASSWORD_ENC
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.db.name" . }}
+      key: {{ include "supabase.secret.db.key.passwordEncoded" . }}
+- name: DB_DATABASE
+  {{- if and .Values.secret.db.secretRef (not (hasKey (default (dict) .Values.secret.db.secretRefKey) "database")) }}
+  value: {{ .Values.secret.db.database | default "postgres" | quote }}
+  {{- else }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.db.name" . }}
+      key: {{ include "supabase.secret.db.key.database" . }}
+  {{- end }}
+- name: JWT_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.jwt.name" . }}
+      key: {{ include "supabase.secret.jwt.key.secret" . }}
+- name: SUPABASE_ANON_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.jwt.name" . }}
+      key: {{ include "supabase.secret.jwt.key.anonKey" . }}
+- name: SUPABASE_SERVICE_ROLE_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.jwt.name" . }}
+      key: {{ include "supabase.secret.jwt.key.serviceKey" . }}
+- name: SUPABASE_PUBLISHABLE_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.apikey.name" . }}
+      key: {{ include "supabase.secret.apikey.key.publishableKey" . }}
+- name: SUPABASE_SECRET_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.apikey.name" . }}
+      key: {{ include "supabase.secret.apikey.key.secretKey" . }}
+- name: SUPABASE_PUBLISHABLE_KEYS
+  value: '{"default":"$(SUPABASE_PUBLISHABLE_KEY)"}'
+- name: SUPABASE_SECRET_KEYS
+  value: '{"default":"$(SUPABASE_SECRET_KEY)"}'
+- name: SUPABASE_DB_URL
+  value: $(DB_DRIVER)://$(DB_USERNAME):$(DB_PASSWORD_ENC)@$(DB_HOSTNAME):$(DB_PORT)/$(DB_DATABASE)?search_path=auth&sslmode=$(DB_SSL)
+{{- end -}}

--- a/charts/supabase/templates/imgproxy/deployment.yaml
+++ b/charts/supabase/templates/imgproxy/deployment.yaml
@@ -35,10 +35,7 @@ spec:
           image: "{{ .Values.image.imgproxy.repository }}:{{ .Values.image.imgproxy.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.imgproxy.pullPolicy }}
           env:
-            {{- range $key, $value := .Values.environment.imgproxy }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
-            {{- end }}
+            {{- include "supabase.imgproxy.env" . | nindent 12 }}
           {{- with .Values.deployment.imgproxy.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}
@@ -89,3 +86,12 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}
+
+---
+
+{{- define "supabase.imgproxy.env" -}}
+{{- range $key, $value := .Values.environment.imgproxy }}
+- name: {{ $key }}
+  value: {{ $value | quote }}
+{{- end }}
+{{- end -}}

--- a/charts/supabase/templates/kong/deployment.yaml
+++ b/charts/supabase/templates/kong/deployment.yaml
@@ -37,52 +37,7 @@ spec:
           command: ["/bin/bash"]
           args: ["/scripts/kong-entrypoint.sh"]
           env:
-            {{- range $key, $value := .Values.environment.kong }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
-            {{- end }}
-            - name: SUPABASE_ANON_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.jwt.name" . }}
-                  key: {{ include "supabase.secret.jwt.key.anonKey" . }}
-            - name: SUPABASE_SERVICE_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.jwt.name" . }}
-                  key: {{ include "supabase.secret.jwt.key.serviceKey" . }}
-            - name: SUPABASE_PUBLISHABLE_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.apikey.name" . }}
-                  key: {{ include "supabase.secret.apikey.key.publishableKey" . }}
-            - name: SUPABASE_SECRET_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.apikey.name" . }}
-                  key: {{ include "supabase.secret.apikey.key.secretKey" . }}
-            - name: ANON_KEY_ASYMMETRIC
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.apikey.name" . }}
-                  key: {{ include "supabase.secret.apikey.key.anonKeyAsymmetric" . }}
-            - name: SERVICE_ROLE_KEY_ASYMMETRIC
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.apikey.name" . }}
-                  key: {{ include "supabase.secret.apikey.key.serviceRoleKeyAsymmetric" . }}
-            {{- if .Values.secret.dashboard }}
-            - name: DASHBOARD_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.dashboard.name" . }}
-                  key: {{ include "supabase.secret.dashboard.key.username" . }}
-            - name: DASHBOARD_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.dashboard.name" . }}
-                  key: {{ include "supabase.secret.dashboard.key.password" . }}
-            {{- end }}
+            {{- include "supabase.kong.env" . | nindent 12 }}
           {{- with .Values.deployment.kong.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}
@@ -139,3 +94,54 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
 {{- end }}
+
+---
+
+{{- define "supabase.kong.env" -}}
+{{- range $key, $value := .Values.environment.kong }}
+- name: {{ $key }}
+  value: {{ $value | quote }}
+{{- end }}
+- name: SUPABASE_ANON_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.jwt.name" . }}
+      key: {{ include "supabase.secret.jwt.key.anonKey" . }}
+- name: SUPABASE_SERVICE_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.jwt.name" . }}
+      key: {{ include "supabase.secret.jwt.key.serviceKey" . }}
+- name: SUPABASE_PUBLISHABLE_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.apikey.name" . }}
+      key: {{ include "supabase.secret.apikey.key.publishableKey" . }}
+- name: SUPABASE_SECRET_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.apikey.name" . }}
+      key: {{ include "supabase.secret.apikey.key.secretKey" . }}
+- name: ANON_KEY_ASYMMETRIC
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.apikey.name" . }}
+      key: {{ include "supabase.secret.apikey.key.anonKeyAsymmetric" . }}
+- name: SERVICE_ROLE_KEY_ASYMMETRIC
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.apikey.name" . }}
+      key: {{ include "supabase.secret.apikey.key.serviceRoleKeyAsymmetric" . }}
+{{- if .Values.secret.dashboard }}
+- name: DASHBOARD_USERNAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.dashboard.name" . }}
+      key: {{ include "supabase.secret.dashboard.key.username" . }}
+- name: DASHBOARD_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.dashboard.name" . }}
+      key: {{ include "supabase.secret.dashboard.key.password" . }}
+{{- end }}
+{{- end -}}

--- a/charts/supabase/templates/meta/deployment.yaml
+++ b/charts/supabase/templates/meta/deployment.yaml
@@ -35,66 +35,7 @@ spec:
           image: "{{ .Values.image.meta.repository }}:{{ .Values.image.meta.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.meta.pullPolicy }}
           env:
-            {{- range $key, $value := .Values.environment.meta }}
-            {{- if not (and (not $.Values.deployment.db.enabled) (or (and (eq $key "DB_HOST") (or (and $.Values.secret.db.secretRef (hasKey (default (dict) $.Values.secret.db.secretRefKey) "host")) $.Values.secret.db.host)) (and (eq $key "DB_PORT") (or (and $.Values.secret.db.secretRef (hasKey (default (dict) $.Values.secret.db.secretRefKey) "port")) $.Values.secret.db.port)))) }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
-            {{- end }}
-            {{- end }}
-            {{- if .Values.deployment.db.enabled }}
-            - name: DB_HOST
-              value: {{ include "supabase.db.fullname" . }}
-            {{- else if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "host") }}
-            - name: DB_HOST
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.host" . }}
-            {{- else if .Values.secret.db.host }}
-            - name: DB_HOST
-              value: {{ .Values.secret.db.host | quote }}
-            {{- end }}
-            {{- if and (not .Values.deployment.db.enabled) .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "port") }}
-            - name: DB_PORT
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.port" . }}
-            {{- else if and (not .Values.deployment.db.enabled) .Values.secret.db.port }}
-            - name: DB_PORT
-              value: {{ .Values.secret.db.port | quote }}
-            {{- end }}
-            - name: DB_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.password" . }}
-            - name: DB_NAME
-              {{- if and .Values.secret.db.secretRef (not (hasKey (default (dict) .Values.secret.db.secretRefKey) "database")) }}
-              value: {{ .Values.secret.db.database | default "postgres" | quote }}
-              {{- else }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.database" . }}
-              {{- end }}
-            - name: PG_META_DB_HOST
-              value: $(DB_HOST)
-            - name: PG_META_DB_PORT
-              value: $(DB_PORT)
-            - name: PG_META_DB_NAME
-              value: $(DB_NAME)
-            - name: PG_META_DB_USER
-              value: $(DB_USER)
-            - name: PG_META_DB_PASSWORD
-              value: $(DB_PASSWORD)
-            - name: PG_META_DB_SSL_MODE
-              value: $(DB_SSL)
-            - name: CRYPTO_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.meta.name" . }}
-                  key: {{ include "supabase.secret.meta.key.cryptoKey" . }}
+            {{- include "supabase.meta.env" . | nindent 12 }}
 
 
           {{- with .Values.deployment.meta.livenessProbe }}
@@ -134,3 +75,68 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}
+
+---
+
+{{- define "supabase.meta.env" -}}
+{{- range $key, $value := .Values.environment.meta }}
+{{- if not (and (not $.Values.deployment.db.enabled) (or (and (eq $key "DB_HOST") (or (and $.Values.secret.db.secretRef (hasKey (default (dict) $.Values.secret.db.secretRefKey) "host")) $.Values.secret.db.host)) (and (eq $key "DB_PORT") (or (and $.Values.secret.db.secretRef (hasKey (default (dict) $.Values.secret.db.secretRefKey) "port")) $.Values.secret.db.port)))) }}
+- name: {{ $key }}
+  value: {{ $value | quote }}
+{{- end }}
+{{- end }}
+{{- if .Values.deployment.db.enabled }}
+- name: DB_HOST
+  value: {{ include "supabase.db.fullname" . }}
+{{- else if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "host") }}
+- name: DB_HOST
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.db.name" . }}
+      key: {{ include "supabase.secret.db.key.host" . }}
+{{- else if .Values.secret.db.host }}
+- name: DB_HOST
+  value: {{ .Values.secret.db.host | quote }}
+{{- end }}
+{{- if and (not .Values.deployment.db.enabled) .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "port") }}
+- name: DB_PORT
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.db.name" . }}
+      key: {{ include "supabase.secret.db.key.port" . }}
+{{- else if and (not .Values.deployment.db.enabled) .Values.secret.db.port }}
+- name: DB_PORT
+  value: {{ .Values.secret.db.port | quote }}
+{{- end }}
+- name: DB_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.db.name" . }}
+      key: {{ include "supabase.secret.db.key.password" . }}
+- name: DB_NAME
+  {{- if and .Values.secret.db.secretRef (not (hasKey (default (dict) .Values.secret.db.secretRefKey) "database")) }}
+  value: {{ .Values.secret.db.database | default "postgres" | quote }}
+  {{- else }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.db.name" . }}
+      key: {{ include "supabase.secret.db.key.database" . }}
+  {{- end }}
+- name: PG_META_DB_HOST
+  value: $(DB_HOST)
+- name: PG_META_DB_PORT
+  value: $(DB_PORT)
+- name: PG_META_DB_NAME
+  value: $(DB_NAME)
+- name: PG_META_DB_USER
+  value: $(DB_USER)
+- name: PG_META_DB_PASSWORD
+  value: $(DB_PASSWORD)
+- name: PG_META_DB_SSL_MODE
+  value: $(DB_SSL)
+- name: CRYPTO_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.meta.name" . }}
+      key: {{ include "supabase.secret.meta.key.cryptoKey" . }}
+{{- end -}}

--- a/charts/supabase/templates/minio/deployment.yaml
+++ b/charts/supabase/templates/minio/deployment.yaml
@@ -41,21 +41,7 @@ spec:
             - ":9001"
             - /data
           env:
-            - name: MINIO_ROOT_USER
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.minio.name" . }}
-                  key: {{ include "supabase.secret.minio.key.user" . }}
-            - name: MINIO_ROOT_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  {{- if .Values.secret.s3.secretRef }}
-                  name: {{ include "supabase.secret.s3.name" . }}
-                  key: {{ include "supabase.secret.s3.key.password" . }}
-                  {{- else }}
-                  name: {{ include "supabase.secret.minio.name" . }}
-                  key: {{ include "supabase.secret.minio.key.password" . }}
-                  {{- end }}
+            {{- include "supabase.minio.env" . | nindent 12 }}
           {{- with .Values.deployment.minio.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}
@@ -103,3 +89,23 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
 {{- end }}
+
+---
+
+{{- define "supabase.minio.env" -}}
+- name: MINIO_ROOT_USER
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.minio.name" . }}
+      key: {{ include "supabase.secret.minio.key.user" . }}
+- name: MINIO_ROOT_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      {{- if .Values.secret.s3.secretRef }}
+      name: {{ include "supabase.secret.s3.name" . }}
+      key: {{ include "supabase.secret.s3.key.password" . }}
+      {{- else }}
+      name: {{ include "supabase.secret.minio.name" . }}
+      key: {{ include "supabase.secret.minio.key.password" . }}
+      {{- end }}
+{{- end -}}

--- a/charts/supabase/templates/realtime/deployment.yaml
+++ b/charts/supabase/templates/realtime/deployment.yaml
@@ -33,30 +33,7 @@ spec:
           image: "{{ .Values.image.initDb.repository }}:{{ .Values.image.initDb.tag }}"
           imagePullPolicy: {{ .Values.image.initDb.pullPolicy }}
           env:
-            - name: DB_HOST
-              {{- if .Values.deployment.db.enabled }}
-              value: {{ include "supabase.db.fullname" . | quote }}
-              {{- else if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "host") }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.host" . }}
-              {{- else if .Values.secret.db.host }}
-              value: {{ .Values.secret.db.host | quote }}
-              {{- else }}
-              value: {{ .Values.environment.realtime.DB_HOST | quote }}
-              {{- end }}
-            - name: DB_PORT
-              {{- if and (not .Values.deployment.db.enabled) .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "port") }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.port" . }}
-              {{- else if and (not .Values.deployment.db.enabled) .Values.secret.db.port }}
-              value: {{ .Values.secret.db.port | quote }}
-              {{- else }}
-              value: {{ .Values.environment.realtime.DB_PORT | quote }}
-              {{- end }}
+            {{- include "supabase.realtime.initDbEnv" . | nindent 12 }}
           command: ["/bin/sh", "-c"]
           args:
             - |
@@ -74,74 +51,7 @@ spec:
           command: ["/bin/sh"]
           args: ["-c", "/app/bin/migrate && /app/bin/realtime eval 'Realtime.Release.seeds(Realtime.Repo)' && /app/bin/server"]
           env:
-            {{- range $key, $value := .Values.environment.realtime }}
-            {{- if not (and (not $.Values.deployment.db.enabled) (or (and (eq $key "DB_HOST") (or (and $.Values.secret.db.secretRef (hasKey (default (dict) $.Values.secret.db.secretRefKey) "host")) $.Values.secret.db.host)) (and (eq $key "DB_PORT") (or (and $.Values.secret.db.secretRef (hasKey (default (dict) $.Values.secret.db.secretRefKey) "port")) $.Values.secret.db.port)))) }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
-            {{- end }}
-            {{- end }}
-            {{- if .Values.deployment.db.enabled }}
-            - name: DB_HOST
-              value: {{ include "supabase.db.fullname" . }}
-            {{- else if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "host") }}
-            - name: DB_HOST
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.host" . }}
-            {{- else if .Values.secret.db.host }}
-            - name: DB_HOST
-              value: {{ .Values.secret.db.host | quote }}
-            {{- end }}
-            {{- if and (not .Values.deployment.db.enabled) .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "port") }}
-            - name: DB_PORT
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.port" . }}
-            {{- else if and (not .Values.deployment.db.enabled) .Values.secret.db.port }}
-            - name: DB_PORT
-              value: {{ .Values.secret.db.port | quote }}
-            {{- end }}
-            - name: SELF_HOST_TENANT_NAME
-              value: {{ include "supabase.realtime.fullname" . }}
-            - name: DB_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.password" . }}
-            - name: DB_NAME
-              {{- if and .Values.secret.db.secretRef (not (hasKey (default (dict) .Values.secret.db.secretRefKey) "database")) }}
-              value: {{ .Values.secret.db.database | default "postgres" | quote }}
-              {{- else }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.database" . }}
-              {{- end }}
-            - name: JWT_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.jwt.name" . }}
-                  key: {{ include "supabase.secret.jwt.key.secret" . }}
-            - name: API_JWT_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.jwt.name" . }}
-                  key: {{ include "supabase.secret.jwt.key.secret" . }}
-            {{- if or .Values.secret.apikey.secretRef .Values.secret.apikey.jwtJwks }}
-            - name: API_JWT_JWKS
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.apikey.name" . }}
-                  key: {{ include "supabase.secret.apikey.key.jwtJwks" . }}
-            {{- end }}
-
-            - name: SECRET_KEY_BASE
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.realtime.name" . }}
-                  key: {{ include "supabase.secret.realtime.key.secretKeyBase" . }}
+            {{- include "supabase.realtime.env" . | nindent 12 }}
 
           {{- with .Values.deployment.realtime.livenessProbe }}
           livenessProbe:
@@ -180,3 +90,105 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}
+
+---
+
+{{- define "supabase.realtime.initDbEnv" -}}
+- name: DB_HOST
+  {{- if .Values.deployment.db.enabled }}
+  value: {{ include "supabase.db.fullname" . | quote }}
+  {{- else if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "host") }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.db.name" . }}
+      key: {{ include "supabase.secret.db.key.host" . }}
+  {{- else if .Values.secret.db.host }}
+  value: {{ .Values.secret.db.host | quote }}
+  {{- else }}
+  value: {{ .Values.environment.realtime.DB_HOST | quote }}
+  {{- end }}
+- name: DB_PORT
+  {{- if and (not .Values.deployment.db.enabled) .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "port") }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.db.name" . }}
+      key: {{ include "supabase.secret.db.key.port" . }}
+  {{- else if and (not .Values.deployment.db.enabled) .Values.secret.db.port }}
+  value: {{ .Values.secret.db.port | quote }}
+  {{- else }}
+  value: {{ .Values.environment.realtime.DB_PORT | quote }}
+  {{- end }}
+{{- end -}}
+
+---
+
+{{- define "supabase.realtime.env" -}}
+{{- range $key, $value := .Values.environment.realtime }}
+{{- if not (and (not $.Values.deployment.db.enabled) (or (and (eq $key "DB_HOST") (or (and $.Values.secret.db.secretRef (hasKey (default (dict) $.Values.secret.db.secretRefKey) "host")) $.Values.secret.db.host)) (and (eq $key "DB_PORT") (or (and $.Values.secret.db.secretRef (hasKey (default (dict) $.Values.secret.db.secretRefKey) "port")) $.Values.secret.db.port)))) }}
+- name: {{ $key }}
+  value: {{ $value | quote }}
+{{- end }}
+{{- end }}
+{{- if .Values.deployment.db.enabled }}
+- name: DB_HOST
+  value: {{ include "supabase.db.fullname" . }}
+{{- else if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "host") }}
+- name: DB_HOST
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.db.name" . }}
+      key: {{ include "supabase.secret.db.key.host" . }}
+{{- else if .Values.secret.db.host }}
+- name: DB_HOST
+  value: {{ .Values.secret.db.host | quote }}
+{{- end }}
+{{- if and (not .Values.deployment.db.enabled) .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "port") }}
+- name: DB_PORT
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.db.name" . }}
+      key: {{ include "supabase.secret.db.key.port" . }}
+{{- else if and (not .Values.deployment.db.enabled) .Values.secret.db.port }}
+- name: DB_PORT
+  value: {{ .Values.secret.db.port | quote }}
+{{- end }}
+- name: SELF_HOST_TENANT_NAME
+  value: {{ include "supabase.realtime.fullname" . }}
+- name: DB_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.db.name" . }}
+      key: {{ include "supabase.secret.db.key.password" . }}
+- name: DB_NAME
+  {{- if and .Values.secret.db.secretRef (not (hasKey (default (dict) .Values.secret.db.secretRefKey) "database")) }}
+  value: {{ .Values.secret.db.database | default "postgres" | quote }}
+  {{- else }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.db.name" . }}
+      key: {{ include "supabase.secret.db.key.database" . }}
+  {{- end }}
+- name: JWT_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.jwt.name" . }}
+      key: {{ include "supabase.secret.jwt.key.secret" . }}
+- name: API_JWT_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.jwt.name" . }}
+      key: {{ include "supabase.secret.jwt.key.secret" . }}
+{{- if or .Values.secret.apikey.secretRef .Values.secret.apikey.jwtJwks }}
+- name: API_JWT_JWKS
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.apikey.name" . }}
+      key: {{ include "supabase.secret.apikey.key.jwtJwks" . }}
+{{- end }}
+
+- name: SECRET_KEY_BASE
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.realtime.name" . }}
+      key: {{ include "supabase.secret.realtime.key.secretKeyBase" . }}
+{{- end -}}

--- a/charts/supabase/templates/rest/deployment.yaml
+++ b/charts/supabase/templates/rest/deployment.yaml
@@ -33,30 +33,7 @@ spec:
           image: "{{ .Values.image.initDb.repository }}:{{ .Values.image.initDb.tag }}"
           imagePullPolicy: {{ .Values.image.initDb.pullPolicy }}
           env:
-            - name: DB_HOST
-              {{- if .Values.deployment.db.enabled }}
-              value: {{ include "supabase.db.fullname" . | quote }}
-              {{- else if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "host") }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.host" . }}
-              {{- else if .Values.secret.db.host }}
-              value: {{ .Values.secret.db.host | quote }}
-              {{- else }}
-              value: {{ .Values.environment.rest.DB_HOST | quote }}
-              {{- end }}
-            - name: DB_PORT
-              {{- if and (not .Values.deployment.db.enabled) .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "port") }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.port" . }}
-              {{- else if and (not .Values.deployment.db.enabled) .Values.secret.db.port }}
-              value: {{ .Values.secret.db.port | quote }}
-              {{- else }}
-              value: {{ .Values.environment.rest.DB_PORT | quote }}
-              {{- end }}
+            {{- include "supabase.rest.initDbEnv" . | nindent 12 }}
           command: ["/bin/sh", "-c"]
           args:
             - |
@@ -72,71 +49,7 @@ spec:
           image: "{{ .Values.image.rest.repository }}:{{ .Values.image.rest.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.rest.pullPolicy }}
           env:
-            {{- range $key, $value := .Values.environment.rest }}
-            {{- if not (and (not $.Values.deployment.db.enabled) (or (and (eq $key "DB_HOST") (or (and $.Values.secret.db.secretRef (hasKey (default (dict) $.Values.secret.db.secretRefKey) "host")) $.Values.secret.db.host)) (and (eq $key "DB_PORT") (or (and $.Values.secret.db.secretRef (hasKey (default (dict) $.Values.secret.db.secretRefKey) "port")) $.Values.secret.db.port)))) }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
-            {{- end }}
-            {{- end }}
-            {{- if .Values.deployment.db.enabled }}
-            - name: DB_HOST
-              value: {{ include "supabase.db.fullname" . }}
-            {{- else if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "host") }}
-            - name: DB_HOST
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.host" . }}
-            {{- else if .Values.secret.db.host }}
-            - name: DB_HOST
-              value: {{ .Values.secret.db.host | quote }}
-            {{- end }}
-            {{- if and (not .Values.deployment.db.enabled) .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "port") }}
-            - name: DB_PORT
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.port" . }}
-            {{- else if and (not .Values.deployment.db.enabled) .Values.secret.db.port }}
-            - name: DB_PORT
-              value: {{ .Values.secret.db.port | quote }}
-            {{- end }}
-            - name: DB_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.password" . }}
-            - name: DB_PASSWORD_ENC
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.passwordEncoded" . }}
-            - name: DB_NAME
-              {{- if and .Values.secret.db.secretRef (not (hasKey (default (dict) .Values.secret.db.secretRefKey) "database")) }}
-              value: {{ .Values.secret.db.database | default "postgres" | quote }}
-              {{- else }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.database" . }}
-              {{- end }}
-            - name: PGRST_DB_URI
-              value: $(DB_DRIVER)://$(DB_USER):$(DB_PASSWORD_ENC)@$(DB_HOST):$(DB_PORT)/$(DB_NAME)?sslmode=$(DB_SSL)
-            - name: PGRST_JWT_SECRET
-              valueFrom:
-                secretKeyRef:
-                  {{- if or .Values.secret.apikey.secretRef .Values.secret.apikey.jwtJwks }}
-                  name: {{ include "supabase.secret.apikey.name" . }}
-                  key: {{ include "supabase.secret.apikey.key.jwtJwks" . }}
-                  {{- else }}
-                  name: {{ include "supabase.secret.jwt.name" . }}
-                  key: {{ include "supabase.secret.jwt.key.secret" . }}
-                  {{- end }}
-            - name: PGRST_APP_SETTINGS_JWT_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.jwt.name" . }}
-                  key: {{ include "supabase.secret.jwt.key.secret" . }}
+            {{- include "supabase.rest.env" . | nindent 12 }}
           {{- with .Values.deployment.rest.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}
@@ -174,3 +87,102 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}
+
+--- 
+
+{{- define "supabase.rest.initDbEnv" -}}
+- name: DB_HOST
+  {{- if .Values.deployment.db.enabled }}
+  value: {{ include "supabase.db.fullname" . | quote }}
+  {{- else if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "host") }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.db.name" . }}
+      key: {{ include "supabase.secret.db.key.host" . }}
+  {{- else if .Values.secret.db.host }}
+  value: {{ .Values.secret.db.host | quote }}
+  {{- else }}
+  value: {{ .Values.environment.rest.DB_HOST | quote }}
+  {{- end }}
+- name: DB_PORT
+  {{- if and (not .Values.deployment.db.enabled) .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "port") }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.db.name" . }}
+      key: {{ include "supabase.secret.db.key.port" . }}
+  {{- else if and (not .Values.deployment.db.enabled) .Values.secret.db.port }}
+  value: {{ .Values.secret.db.port | quote }}
+  {{- else }}
+  value: {{ .Values.environment.rest.DB_PORT | quote }}
+  {{- end }}
+{{- end -}}
+
+---
+
+{{- define "supabase.rest.env" -}}
+{{- range $key, $value := .Values.environment.rest }}
+{{- if not (and (not $.Values.deployment.db.enabled) (or (and (eq $key "DB_HOST") (or (and $.Values.secret.db.secretRef (hasKey (default (dict) $.Values.secret.db.secretRefKey) "host")) $.Values.secret.db.host)) (and (eq $key "DB_PORT") (or (and $.Values.secret.db.secretRef (hasKey (default (dict) $.Values.secret.db.secretRefKey) "port")) $.Values.secret.db.port)))) }}
+- name: {{ $key }}
+  value: {{ $value | quote }}
+{{- end }}
+{{- end }}
+{{- if .Values.deployment.db.enabled }}
+- name: DB_HOST
+  value: {{ include "supabase.db.fullname" . }}
+{{- else if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "host") }}
+- name: DB_HOST
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.db.name" . }}
+      key: {{ include "supabase.secret.db.key.host" . }}
+{{- else if .Values.secret.db.host }}
+- name: DB_HOST
+  value: {{ .Values.secret.db.host | quote }}
+{{- end }}
+{{- if and (not .Values.deployment.db.enabled) .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "port") }}
+- name: DB_PORT
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.db.name" . }}
+      key: {{ include "supabase.secret.db.key.port" . }}
+{{- else if and (not .Values.deployment.db.enabled) .Values.secret.db.port }}
+- name: DB_PORT
+  value: {{ .Values.secret.db.port | quote }}
+{{- end }}
+- name: DB_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.db.name" . }}
+      key: {{ include "supabase.secret.db.key.password" . }}
+- name: DB_PASSWORD_ENC
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.db.name" . }}
+      key: {{ include "supabase.secret.db.key.passwordEncoded" . }}
+- name: DB_NAME
+  {{- if and .Values.secret.db.secretRef (not (hasKey (default (dict) .Values.secret.db.secretRefKey) "database")) }}
+  value: {{ .Values.secret.db.database | default "postgres" | quote }}
+  {{- else }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.db.name" . }}
+      key: {{ include "supabase.secret.db.key.database" . }}
+  {{- end }}
+- name: PGRST_DB_URI
+  value: $(DB_DRIVER)://$(DB_USER):$(DB_PASSWORD_ENC)@$(DB_HOST):$(DB_PORT)/$(DB_NAME)?sslmode=$(DB_SSL)
+- name: PGRST_JWT_SECRET
+  valueFrom:
+    secretKeyRef:
+      {{- if or .Values.secret.apikey.secretRef .Values.secret.apikey.jwtJwks }}
+      name: {{ include "supabase.secret.apikey.name" . }}
+      key: {{ include "supabase.secret.apikey.key.jwtJwks" . }}
+      {{- else }}
+      name: {{ include "supabase.secret.jwt.name" . }}
+      key: {{ include "supabase.secret.jwt.key.secret" . }}
+      {{- end }}
+- name: PGRST_APP_SETTINGS_JWT_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.jwt.name" . }}
+      key: {{ include "supabase.secret.jwt.key.secret" . }}
+{{- end -}}

--- a/charts/supabase/templates/storage/deployment.yaml
+++ b/charts/supabase/templates/storage/deployment.yaml
@@ -34,30 +34,7 @@ spec:
           image: "{{ .Values.image.initDb.repository }}:{{ .Values.image.initDb.tag }}"
           imagePullPolicy: {{ .Values.image.initDb.pullPolicy }}
           env:
-            - name: DB_HOST
-              {{- if .Values.deployment.db.enabled }}
-              value: {{ include "supabase.db.fullname" . | quote }}
-              {{- else if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "host") }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.host" . }}
-              {{- else if .Values.secret.db.host }}
-              value: {{ .Values.secret.db.host | quote }}
-              {{- else }}
-              value: {{ .Values.environment.storage.DB_HOST | quote }}
-              {{- end }}
-            - name: DB_PORT
-              {{- if and (not .Values.deployment.db.enabled) .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "port") }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.port" . }}
-              {{- else if and (not .Values.deployment.db.enabled) .Values.secret.db.port }}
-              value: {{ .Values.secret.db.port | quote }}
-              {{- else }}
-              value: {{ .Values.environment.storage.DB_PORT | quote }}
-              {{- end }}
+            {{- include "supabase.storage.initDbEnv" . | nindent 12 }}
           command: ["/bin/sh", "-c"]
           args:
             - |
@@ -70,23 +47,7 @@ spec:
         - name: init-bucket
           image: "{{ .Values.image.minioClient.repository }}:{{ .Values.image.minioClient.tag }}"
           env:
-            - name: MINIO_ROOT_USER
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.minio.name" . }}
-                  key: {{ include "supabase.secret.minio.key.user" . }}
-            - name: MINIO_ROOT_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  {{- if .Values.secret.s3.secretRef }}
-                  name: {{ include "supabase.secret.s3.name" . }}
-                  key: {{ include "supabase.secret.s3.key.password" . }}
-                  {{- else }}
-                  name: {{ include "supabase.secret.minio.name" . }}
-                  key: {{ include "supabase.secret.minio.key.password" . }}
-                  {{- end }}
-            - name: GLOBAL_S3_BUCKET
-              value: {{ .Values.environment.storage.GLOBAL_S3_BUCKET }}
+            {{- include "supabase.storage.initBucketEnv" . | nindent 12 }}
           imagePullPolicy: {{ .Values.image.minioClient.pullPolicy }}
           command:
             - /bin/sh
@@ -108,145 +69,7 @@ spec:
           image: "{{ .Values.image.storage.repository }}:{{ .Values.image.storage.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.storage.pullPolicy }}
           env:
-            {{- range $key, $value := .Values.environment.storage }}
-            {{- if and (ne $key "AWS_ACCESS_KEY_ID") (ne $key "AWS_SECRET_ACCESS_KEY") (ne $key "STORAGE_BACKEND") (not (and (not $.Values.deployment.db.enabled) (or (and (eq $key "DB_HOST") (or (and $.Values.secret.db.secretRef (hasKey (default (dict) $.Values.secret.db.secretRefKey) "host")) $.Values.secret.db.host)) (and (eq $key "DB_PORT") (or (and $.Values.secret.db.secretRef (hasKey (default (dict) $.Values.secret.db.secretRefKey) "port")) $.Values.secret.db.port))))) }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
-            {{- end }}
-            {{- end }}
-            
-            # 2. Now handle STORAGE_BACKEND specifically
-            - name: STORAGE_BACKEND
-              value: {{ if hasKey .Values.environment.storage "STORAGE_BACKEND" -}}
-                {{ index .Values.environment.storage "STORAGE_BACKEND" | quote }}
-              {{- else if .Values.deployment.minio.enabled -}}
-                "s3"
-              {{- else -}}
-                "file"
-              {{- end }}
-
-            {{- if or .Values.secret.s3.secretRef .Values.deployment.minio.enabled }}
-            - name: AWS_ACCESS_KEY_ID
-              valueFrom:
-                secretKeyRef:
-                  {{- if .Values.secret.s3.secretRef }}
-                  name: {{ include "supabase.secret.s3.name" . | quote }}
-                  key: {{ include "supabase.secret.s3.key.keyId" . | quote }}
-                  {{- else }}
-                  name: {{ include "supabase.secret.minio.name" . }}
-                  key: {{ include "supabase.secret.minio.key.user" . }}
-                  {{- end }}
-
-            - name: AWS_SECRET_ACCESS_KEY
-              valueFrom:
-                secretKeyRef:
-                  {{- if .Values.secret.s3.secretRef }}
-                  name: {{ include "supabase.secret.s3.name" . | quote }}
-                  key: {{ include "supabase.secret.s3.key.accessKey" . | quote }}
-                  {{- else }}
-                  name: {{ include "supabase.secret.minio.name" . }}
-                  key: {{ include "supabase.secret.minio.key.password" . }}
-                  {{- end }}
-            {{- end }}
-
-            {{- if .Values.deployment.db.enabled }}
-            - name: DB_HOST
-              value: {{ include "supabase.db.fullname" . }}
-            {{- else if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "host") }}
-            - name: DB_HOST
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.host" . }}
-            {{- else if .Values.secret.db.host }}
-            - name: DB_HOST
-              value: {{ .Values.secret.db.host | quote }}
-            {{- end }}
-            {{- if and (not .Values.deployment.db.enabled) .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "port") }}
-            - name: DB_PORT
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.port" . }}
-            {{- else if and (not .Values.deployment.db.enabled) .Values.secret.db.port }}
-            - name: DB_PORT
-              value: {{ .Values.secret.db.port | quote }}
-            {{- end }}
-            {{- if .Values.deployment.rest.enabled }}
-            - name: POSTGREST_URL
-              value: http://{{ include "supabase.rest.fullname" . }}:{{ .Values.service.rest.port }}
-            {{- end }}
-            - name: DB_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.password" . }}
-            - name: DB_PASSWORD_ENC
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.passwordEncoded" . }}
-            - name: DB_NAME
-              {{- if and .Values.secret.db.secretRef (not (hasKey (default (dict) .Values.secret.db.secretRefKey) "database")) }}
-              value: {{ .Values.secret.db.database | default "postgres" | quote }}
-              {{- else }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.database" . }}
-              {{- end }}
-            - name: DATABASE_URL
-              value: $(DB_DRIVER)://$(DB_USER):$(DB_PASSWORD_ENC)@$(DB_HOST):$(DB_PORT)/$(DB_NAME)?sslmode=$(DB_SSL)
-            - name: PGRST_JWT_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.jwt.name" . }}
-                  key: {{ include "supabase.secret.jwt.key.secret" . }}
-            - name: AUTH_JWT_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.jwt.name" . }}
-                  key: {{ include "supabase.secret.jwt.key.secret" . }}
-            {{- if or .Values.secret.apikey.secretRef .Values.secret.apikey.jwtJwks }}
-            - name: JWT_JWKS
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.apikey.name" . }}
-                  key: {{ include "supabase.secret.apikey.key.jwtJwks" . }}
-            {{- end }}
-            - name: ANON_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.jwt.name" . }}
-                  key: {{ include "supabase.secret.jwt.key.anonKey" . }}
-            - name: SERVICE_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.jwt.name" . }}
-                  key: {{ include "supabase.secret.jwt.key.serviceKey" . }}
-            - name: S3_PROTOCOL_ACCESS_KEY_ID
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.s3.name" . }}
-                  key: {{ include "supabase.secret.s3.key.keyId" . }}
-            - name: S3_PROTOCOL_ACCESS_KEY_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.s3.name" . }}
-                  key: {{ include "supabase.secret.s3.key.accessKey" . }}
-            {{- if .Values.deployment.imgproxy.enabled }}
-            - name: IMGPROXY_URL
-              value: http://{{ include "supabase.imgproxy.fullname" . }}:{{ .Values.service.imgproxy.port | int }}
-            {{- end }}
-              
-            {{- if .Values.deployment.minio.enabled }}
-            - name: GLOBAL_S3_ENDPOINT
-              value: http://{{ include "supabase.minio.fullname" . }}:{{ default 9000 .Values.service.minio.port }}
-            - name: GLOBAL_S3_PROTOCOl
-              value: http
-            - name: GLOBAL_S3_FORCE_PATH_STYLE
-              value: "true"
-            {{- end }}
+            {{- include "supabase.storage.env" . | nindent 12 }}
           {{- with .Values.deployment.storage.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}
@@ -294,3 +117,196 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
 {{- end }}
+
+---
+
+{{- define "supabase.storage.initDbEnv" -}}
+- name: DB_HOST
+  {{- if .Values.deployment.db.enabled }}
+  value: {{ include "supabase.db.fullname" . | quote }}
+  {{- else if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "host") }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.db.name" . }}
+      key: {{ include "supabase.secret.db.key.host" . }}
+  {{- else if .Values.secret.db.host }}
+  value: {{ .Values.secret.db.host | quote }}
+  {{- else }}
+  value: {{ .Values.environment.storage.DB_HOST | quote }}
+  {{- end }}
+- name: DB_PORT
+  {{- if and (not .Values.deployment.db.enabled) .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "port") }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.db.name" . }}
+      key: {{ include "supabase.secret.db.key.port" . }}
+  {{- else if and (not .Values.deployment.db.enabled) .Values.secret.db.port }}
+  value: {{ .Values.secret.db.port | quote }}
+  {{- else }}
+  value: {{ .Values.environment.storage.DB_PORT | quote }}
+  {{- end }}
+{{- end -}}
+
+---
+
+{{- define "supabase.storage.initBucketEnv" -}}
+- name: MINIO_ROOT_USER
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.minio.name" . }}
+      key: {{ include "supabase.secret.minio.key.user" . }}
+- name: MINIO_ROOT_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      {{- if .Values.secret.s3.secretRef }}
+      name: {{ include "supabase.secret.s3.name" . }}
+      key: {{ include "supabase.secret.s3.key.password" . }}
+      {{- else }}
+      name: {{ include "supabase.secret.minio.name" . }}
+      key: {{ include "supabase.secret.minio.key.password" . }}
+      {{- end }}
+- name: GLOBAL_S3_BUCKET
+  value: {{ .Values.environment.storage.GLOBAL_S3_BUCKET }}
+{{- end -}}
+
+{{- define "supabase.storage.env" -}}
+{{- range $key, $value := .Values.environment.storage }}
+{{- if and (ne $key "AWS_ACCESS_KEY_ID") (ne $key "AWS_SECRET_ACCESS_KEY") (ne $key "STORAGE_BACKEND") (not (and (not $.Values.deployment.db.enabled) (or (and (eq $key "DB_HOST") (or (and $.Values.secret.db.secretRef (hasKey (default (dict) $.Values.secret.db.secretRefKey) "host")) $.Values.secret.db.host)) (and (eq $key "DB_PORT") (or (and $.Values.secret.db.secretRef (hasKey (default (dict) $.Values.secret.db.secretRefKey) "port")) $.Values.secret.db.port))))) }}
+- name: {{ $key }}
+  value: {{ $value | quote }}
+{{- end }}
+{{- end }}
+
+# 2. Now handle STORAGE_BACKEND specifically
+- name: STORAGE_BACKEND
+  value: {{ if hasKey .Values.environment.storage "STORAGE_BACKEND" -}}
+    {{ index .Values.environment.storage "STORAGE_BACKEND" | quote }}
+  {{- else if .Values.deployment.minio.enabled -}}
+    "s3"
+  {{- else -}}
+    "file"
+  {{- end }}
+
+{{- if or .Values.secret.s3.secretRef .Values.deployment.minio.enabled }}
+- name: AWS_ACCESS_KEY_ID
+  valueFrom:
+    secretKeyRef:
+      {{- if .Values.secret.s3.secretRef }}
+      name: {{ include "supabase.secret.s3.name" . | quote }}
+      key: {{ include "supabase.secret.s3.key.keyId" . | quote }}
+      {{- else }}
+      name: {{ include "supabase.secret.minio.name" . }}
+      key: {{ include "supabase.secret.minio.key.user" . }}
+      {{- end }}
+
+- name: AWS_SECRET_ACCESS_KEY
+  valueFrom:
+    secretKeyRef:
+      {{- if .Values.secret.s3.secretRef }}
+      name: {{ include "supabase.secret.s3.name" . | quote }}
+      key: {{ include "supabase.secret.s3.key.accessKey" . | quote }}
+      {{- else }}
+      name: {{ include "supabase.secret.minio.name" . }}
+      key: {{ include "supabase.secret.minio.key.password" . }}
+      {{- end }}
+{{- end }}
+
+{{- if .Values.deployment.db.enabled }}
+- name: DB_HOST
+  value: {{ include "supabase.db.fullname" . }}
+{{- else if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "host") }}
+- name: DB_HOST
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.db.name" . }}
+      key: {{ include "supabase.secret.db.key.host" . }}
+{{- else if .Values.secret.db.host }}
+- name: DB_HOST
+  value: {{ .Values.secret.db.host | quote }}
+{{- end }}
+{{- if and (not .Values.deployment.db.enabled) .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "port") }}
+- name: DB_PORT
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.db.name" . }}
+      key: {{ include "supabase.secret.db.key.port" . }}
+{{- else if and (not .Values.deployment.db.enabled) .Values.secret.db.port }}
+- name: DB_PORT
+  value: {{ .Values.secret.db.port | quote }}
+{{- end }}
+{{- if .Values.deployment.rest.enabled }}
+- name: POSTGREST_URL
+  value: http://{{ include "supabase.rest.fullname" . }}:{{ .Values.service.rest.port }}
+{{- end }}
+- name: DB_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.db.name" . }}
+      key: {{ include "supabase.secret.db.key.password" . }}
+- name: DB_PASSWORD_ENC
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.db.name" . }}
+      key: {{ include "supabase.secret.db.key.passwordEncoded" . }}
+- name: DB_NAME
+  {{- if and .Values.secret.db.secretRef (not (hasKey (default (dict) .Values.secret.db.secretRefKey) "database")) }}
+  value: {{ .Values.secret.db.database | default "postgres" | quote }}
+  {{- else }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.db.name" . }}
+      key: {{ include "supabase.secret.db.key.database" . }}
+  {{- end }}
+- name: DATABASE_URL
+  value: $(DB_DRIVER)://$(DB_USER):$(DB_PASSWORD_ENC)@$(DB_HOST):$(DB_PORT)/$(DB_NAME)?sslmode=$(DB_SSL)
+- name: PGRST_JWT_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.jwt.name" . }}
+      key: {{ include "supabase.secret.jwt.key.secret" . }}
+- name: AUTH_JWT_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.jwt.name" . }}
+      key: {{ include "supabase.secret.jwt.key.secret" . }}
+{{- if or .Values.secret.apikey.secretRef .Values.secret.apikey.jwtJwks }}
+- name: JWT_JWKS
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.apikey.name" . }}
+      key: {{ include "supabase.secret.apikey.key.jwtJwks" . }}
+{{- end }}
+- name: ANON_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.jwt.name" . }}
+      key: {{ include "supabase.secret.jwt.key.anonKey" . }}
+- name: SERVICE_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.jwt.name" . }}
+      key: {{ include "supabase.secret.jwt.key.serviceKey" . }}
+- name: S3_PROTOCOL_ACCESS_KEY_ID
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.s3.name" . }}
+      key: {{ include "supabase.secret.s3.key.keyId" . }}
+- name: S3_PROTOCOL_ACCESS_KEY_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.s3.name" . }}
+      key: {{ include "supabase.secret.s3.key.accessKey" . }}
+{{- if .Values.deployment.imgproxy.enabled }}
+- name: IMGPROXY_URL
+  value: http://{{ include "supabase.imgproxy.fullname" . }}:{{ .Values.service.imgproxy.port | int }}
+{{- end }}
+
+{{- if .Values.deployment.minio.enabled }}
+- name: GLOBAL_S3_ENDPOINT
+  value: http://{{ include "supabase.minio.fullname" . }}:{{ default 9000 .Values.service.minio.port }}
+- name: GLOBAL_S3_PROTOCOl
+  value: http
+- name: GLOBAL_S3_FORCE_PATH_STYLE
+  value: "true"
+{{- end }}
+{{- end -}}

--- a/charts/supabase/templates/studio/deployment.yaml
+++ b/charts/supabase/templates/studio/deployment.yaml
@@ -35,93 +35,7 @@ spec:
           image: "{{ .Values.image.studio.repository }}:{{ .Values.image.studio.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.studio.pullPolicy }}
           env:
-            {{- range $key, $value := .Values.environment.studio }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
-            {{- end }}
-            {{- if .Values.deployment.kong.enabled }}
-            - name: SUPABASE_URL
-              value: http://{{ include "supabase.kong.fullname" . }}:{{ .Values.service.kong.port }}
-            {{- end }}
-            {{- if .Values.deployment.meta.enabled }}
-            - name: STUDIO_PG_META_URL
-              value: http://{{ include "supabase.meta.fullname" . }}:{{ .Values.service.meta.port }}
-            {{- end }}
-
-            {{- if .Values.deployment.db.enabled }}
-            - name: POSTGRES_HOST
-              value: {{ include "supabase.db.fullname" . }}
-            {{- end }}
-
-            - name: POSTGRES_DB
-              {{- if and .Values.secret.db.secretRef (not (hasKey (default (dict) .Values.secret.db.secretRefKey) "database")) }}
-              value: {{ .Values.secret.db.database | default "postgres" | quote }}
-              {{- else }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.database" . }}
-              {{- end }}
-
-            - name: POSTGRES_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.password" . }}
-
-            - name: PG_META_CRYPTO_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.meta.name" . }}
-                  key: {{ include "supabase.secret.meta.key.cryptoKey" . }}
-
-
-            - name: OPENAI_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.dashboard.name" . }}
-                  key: {{ include "supabase.secret.dashboard.key.openAiApiKey" . }}
-
-            - name: SUPABASE_ANON_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.jwt.name" . }}
-                  key: {{ include "supabase.secret.jwt.key.anonKey" . }}
-
-            - name: SUPABASE_SERVICE_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.jwt.name" . }}
-                  key: {{ include "supabase.secret.jwt.key.serviceKey" . }}
-
-            - name: AUTH_JWT_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.jwt.name" . }}
-                  key: {{ include "supabase.secret.jwt.key.secret" . }}
-
-            {{- if .Values.deployment.analytics.enabled }}
-            - name: LOGFLARE_URL
-              value: http://{{ include "supabase.analytics.fullname" . }}:{{ .Values.service.analytics.port }}
-            - name:  LOGFLARE_PUBLIC_ACCESS_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.analytics.name" . }}
-                  key: {{ include "supabase.secret.analytics.key.publicAccessToken" . }}
-            - name: LOGFLARE_PRIVATE_ACCESS_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.analytics.name" . }}
-                  key: {{ include "supabase.secret.analytics.key.privateAccessToken" . }}
-            {{- end }}
-            {{- if .Values.persistence.functions.enabled }}
-            - name: EDGE_FUNCTIONS_MANAGEMENT_FOLDER
-              value: /home/deno/functions
-            {{- end }}
-            {{- if .Values.persistence.snippets.enabled }}
-            - name: SNIPPETS_MANAGEMENT_FOLDER
-              value: /app/snippets
-            {{- end }}
+            {{- include "supabase.studio.env" . | nindent 12 }}
           {{- with .Values.deployment.studio.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}
@@ -181,3 +95,95 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}
+
+---
+
+{{- define "supabase.studio.env" -}}
+{{- range $key, $value := .Values.environment.studio }}
+- name: {{ $key }}
+  value: {{ $value | quote }}
+{{- end }}
+{{- if .Values.deployment.kong.enabled }}
+- name: SUPABASE_URL
+  value: http://{{ include "supabase.kong.fullname" . }}:{{ .Values.service.kong.port }}
+{{- end }}
+{{- if .Values.deployment.meta.enabled }}
+- name: STUDIO_PG_META_URL
+  value: http://{{ include "supabase.meta.fullname" . }}:{{ .Values.service.meta.port }}
+{{- end }}
+
+{{- if .Values.deployment.db.enabled }}
+- name: POSTGRES_HOST
+  value: {{ include "supabase.db.fullname" . }}
+{{- end }}
+
+- name: POSTGRES_DB
+  {{- if and .Values.secret.db.secretRef (not (hasKey (default (dict) .Values.secret.db.secretRefKey) "database")) }}
+  value: {{ .Values.secret.db.database | default "postgres" | quote }}
+  {{- else }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.db.name" . }}
+      key: {{ include "supabase.secret.db.key.database" . }}
+  {{- end }}
+
+- name: POSTGRES_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.db.name" . }}
+      key: {{ include "supabase.secret.db.key.password" . }}
+
+- name: PG_META_CRYPTO_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.meta.name" . }}
+      key: {{ include "supabase.secret.meta.key.cryptoKey" . }}
+
+
+- name: OPENAI_API_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.dashboard.name" . }}
+      key: {{ include "supabase.secret.dashboard.key.openAiApiKey" . }}
+
+- name: SUPABASE_ANON_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.jwt.name" . }}
+      key: {{ include "supabase.secret.jwt.key.anonKey" . }}
+
+- name: SUPABASE_SERVICE_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.jwt.name" . }}
+      key: {{ include "supabase.secret.jwt.key.serviceKey" . }}
+
+- name: AUTH_JWT_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.jwt.name" . }}
+      key: {{ include "supabase.secret.jwt.key.secret" . }}
+
+{{- if .Values.deployment.analytics.enabled }}
+- name: LOGFLARE_URL
+  value: http://{{ include "supabase.analytics.fullname" . }}:{{ .Values.service.analytics.port }}
+- name:  LOGFLARE_PUBLIC_ACCESS_TOKEN
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.analytics.name" . }}
+      key: {{ include "supabase.secret.analytics.key.publicAccessToken" . }}
+- name: LOGFLARE_PRIVATE_ACCESS_TOKEN
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.analytics.name" . }}
+      key: {{ include "supabase.secret.analytics.key.privateAccessToken" . }}
+{{- end }}
+{{- if .Values.persistence.functions.enabled }}
+- name: EDGE_FUNCTIONS_MANAGEMENT_FOLDER
+  value: /home/deno/functions
+{{- end }}
+{{- if .Values.persistence.snippets.enabled }}
+- name: SNIPPETS_MANAGEMENT_FOLDER
+  value: /app/snippets
+{{- end }}
+{{- end -}}

--- a/charts/supabase/templates/vector/deployment.yaml
+++ b/charts/supabase/templates/vector/deployment.yaml
@@ -40,21 +40,7 @@ spec:
           image: "{{ .Values.image.vector.repository }}:{{ .Values.image.vector.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.vector.pullPolicy }}
           env:
-            {{- range $key, $value := .Values.environment.vector }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
-            {{- end }}
-            - name: VECTOR_SELF_NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            {{- if .Values.deployment.analytics.enabled }}
-            - name:  LOGFLARE_PUBLIC_ACCESS_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.analytics.name" . }}
-                  key: {{ include "supabase.secret.analytics.key.publicAccessToken" . }}
-            {{- end }}
+            {{- include "supabase.vector.env" . | nindent 12 }}
           {{- with .Values.deployment.vector.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}
@@ -110,3 +96,23 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}
+
+---
+
+{{- define "supabase.vector.env" -}}
+{{- range $key, $value := .Values.environment.vector }}
+- name: {{ $key }}
+  value: {{ $value | quote }}
+{{- end }}
+- name: VECTOR_SELF_NODE_NAME
+  valueFrom:
+    fieldRef:
+      fieldPath: spec.nodeName
+{{- if .Values.deployment.analytics.enabled }}
+- name:  LOGFLARE_PUBLIC_ACCESS_TOKEN
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.analytics.name" . }}
+      key: {{ include "supabase.secret.analytics.key.publicAccessToken" . }}
+{{- end }}
+{{- end -}}


### PR DESCRIPTION
## What kind of change does this PR introduce?
Refactor / maintenance update (no intended functional behavior change).
## What is the current behavior?
Environment variable sections are defined inline inside each deployment template, which creates duplication across services and makes chart templates harder to read and maintain.
## What is the new behavior?
Environment blocks were extracted into named Helm `define` helpers (for example, `supabase.auth.env`, `supabase.storage.env`, `supabase.db.initExternalEnv`, etc.) and then reused in the deployment templates.
This keeps rendered manifests equivalent in behavior while improving readability and maintainability of chart templates.