### PR TITLE
refactor(helm): standardize DB host/port sourcing via secrets and helper

### DIFF
--- a/charts/supabase/README.md
+++ b/charts/supabase/README.md
@@ -122,7 +122,7 @@ secret:
 
 The secret can be created with kubectl via command-line:
 
-> If you depend on database providers like [StackGres](https://stackgres.io/), [Postgres Operator](https://github.com/zalando/postgres-operator) or self-hosted Postgres instance, fill in the secret above and modify any relevant Postgres attributes such as port or hostname (e.g. `PGPORT`, `DB_HOST`) for any relevant deployments. Refer to [values.yaml](values.yaml) for more details.
+> If you depend on database providers like [StackGres](https://stackgres.io/), [Postgres Operator](https://github.com/zalando/postgres-operator) or self-hosted Postgres instance, configure `secret.db.host`/`secret.db.port` (or map `host`/`port` from `secret.db.secretRef`) and adjust any additional Postgres attributes (e.g. `PGPORT`) as needed. Refer to [values.yaml](values.yaml) for more details.
 
 ### Dashboard secret
 

--- a/charts/supabase/templates/analytics/deployment.yaml
+++ b/charts/supabase/templates/analytics/deployment.yaml
@@ -33,32 +33,8 @@ spec:
           image: "{{ .Values.image.initDb.repository }}:{{ .Values.image.initDb.tag }}"
           imagePullPolicy: {{ .Values.image.initDb.pullPolicy }}
           env:
-            - name: DB_HOST
-              {{- if .Values.deployment.db.enabled }}
-              value: {{ include "supabase.db.fullname" . | quote }}
-              {{- else if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "host") }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.host" . }}
-              {{- else if .Values.secret.db.host }}
-              value: {{ .Values.secret.db.host | quote }}
-              {{- else }}
-              value: {{ .Values.environment.analytics.DB_HOST | quote }}
-              {{- end }}
-            - name: DB_USER
-              value: $(DB_USERNAME)
-            - name: DB_PORT
-              {{- if and (not .Values.deployment.db.enabled) .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "port") }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.port" . }}
-              {{- else if and (not .Values.deployment.db.enabled) .Values.secret.db.port }}
-              value: {{ .Values.secret.db.port | quote }}
-              {{- else }}
-              value: {{ .Values.environment.analytics.DB_PORT | quote }}
-              {{- end }}
+            {{- include "supabase.db.hostEnv" (dict "root" . "name" "DB_HOST") | nindent 12 }}
+            {{- include "supabase.db.portEnv" (dict "root" . "name" "DB_PORT") | nindent 12 }}
           command: ["/bin/sh", "-c"]
           args:
             - |
@@ -75,24 +51,13 @@ spec:
           imagePullPolicy: {{ .Values.image.analytics.pullPolicy }}
           env:
             {{- range $key, $value := .Values.environment.analytics }}
-            {{- if not (and (not $.Values.deployment.db.enabled) (or (and (eq $key "DB_HOST") (or (and $.Values.secret.db.secretRef (hasKey (default (dict) $.Values.secret.db.secretRefKey) "host")) $.Values.secret.db.host)) (and (eq $key "DB_PORT") (or (and $.Values.secret.db.secretRef (hasKey (default (dict) $.Values.secret.db.secretRefKey) "port")) $.Values.secret.db.port)))) }}
+            {{- if and (ne $key "DB_HOST") (ne $key "DB_PORT") }}
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
             {{- end }}
-            - name: DB_HOSTNAME
-              {{- if .Values.deployment.db.enabled }}
-              value: {{ include "supabase.db.fullname" . | quote }}
-              {{- else if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "host") }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.host" . }}
-              {{- else if .Values.secret.db.host }}
-              value: {{ .Values.secret.db.host | quote }}
-              {{- else }}
-              value: {{ .Values.environment.analytics.DB_HOST | quote }}
-              {{- end }}
+            {{- include "supabase.db.hostEnv" (dict "root" . "name" "DB_HOSTNAME") | nindent 12 }}
+            {{- include "supabase.db.portEnv" (dict "root" . "name" "DB_PORT") | nindent 12 }}
             - name: DB_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/supabase/templates/auth/deployment.yaml
+++ b/charts/supabase/templates/auth/deployment.yaml
@@ -33,30 +33,8 @@ spec:
           image: "{{ .Values.image.initDb.repository }}:{{ .Values.image.initDb.tag }}"
           imagePullPolicy: {{ .Values.image.initDb.pullPolicy }}
           env:
-            - name: DB_HOST
-              {{- if .Values.deployment.db.enabled }}
-              value: {{ include "supabase.db.fullname" . | quote }}
-              {{- else if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "host") }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.host" . }}
-              {{- else if .Values.secret.db.host }}
-              value: {{ .Values.secret.db.host | quote }}
-              {{- else }}
-              value: {{ .Values.environment.auth.DB_HOST | quote }}
-              {{- end }}
-            - name: DB_PORT
-              {{- if and (not .Values.deployment.db.enabled) .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "port") }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.port" . }}
-              {{- else if and (not .Values.deployment.db.enabled) .Values.secret.db.port }}
-              value: {{ .Values.secret.db.port | quote }}
-              {{- else }}
-              value: {{ .Values.environment.auth.DB_PORT | quote }}
-              {{- end }}
+            {{- include "supabase.db.hostEnv" (dict "root" . "name" "DB_HOST") | nindent 12 }}
+            {{- include "supabase.db.portEnv" (dict "root" . "name" "DB_PORT") | nindent 12 }}
           command: ["/bin/sh", "-c"]
           args:
             - |
@@ -73,34 +51,13 @@ spec:
           imagePullPolicy: {{ .Values.image.auth.pullPolicy }}
           env:
             {{- range $key, $value := .Values.environment.auth }}
-            {{- if not (and (not $.Values.deployment.db.enabled) (or (and (eq $key "DB_HOST") (or (and $.Values.secret.db.secretRef (hasKey (default (dict) $.Values.secret.db.secretRefKey) "host")) $.Values.secret.db.host)) (and (eq $key "DB_PORT") (or (and $.Values.secret.db.secretRef (hasKey (default (dict) $.Values.secret.db.secretRefKey) "port")) $.Values.secret.db.port)))) }}
+            {{- if and (ne $key "DB_HOST") (ne $key "DB_PORT") }}
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
             {{- end }}
-            {{- if .Values.deployment.db.enabled }}
-            - name: DB_HOST
-              value: {{ include "supabase.db.fullname" . }}
-            {{- else if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "host") }}
-            - name: DB_HOST
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.host" . }}
-            {{- else if .Values.secret.db.host }}
-            - name: DB_HOST
-              value: {{ .Values.secret.db.host | quote }}
-            {{- end }}
-            {{- if and (not .Values.deployment.db.enabled) .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "port") }}
-            - name: DB_PORT
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.port" . }}
-            {{- else if and (not .Values.deployment.db.enabled) .Values.secret.db.port }}
-            - name: DB_PORT
-              value: {{ .Values.secret.db.port | quote }}
-            {{- end }}
+            {{- include "supabase.db.hostEnv" (dict "root" . "name" "DB_HOST") | nindent 12 }}
+            {{- include "supabase.db.portEnv" (dict "root" . "name" "DB_PORT") | nindent 12 }}
             - name: DB_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/supabase/templates/db/_helpers.tpl
+++ b/charts/supabase/templates/db/_helpers.tpl
@@ -41,3 +41,45 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.db.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Render a standardized DB host env var.
+Usage: include "supabase.db.hostEnv" (dict "root" . "name" "DB_HOST")
+*/}}
+{{- define "supabase.db.hostEnv" -}}
+{{- $root := .root -}}
+- name: {{ .name }}
+  {{- if $root.Values.deployment.db.enabled }}
+  value: {{ include "supabase.db.fullname" $root | quote }}
+  {{- else if and $root.Values.secret.db.secretRef (hasKey (default (dict) $root.Values.secret.db.secretRefKey) "host") }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.db.name" $root }}
+      key: {{ include "supabase.secret.db.key.host" $root }}
+  {{- else if $root.Values.secret.db.host }}
+  value: {{ $root.Values.secret.db.host | quote }}
+  {{- else }}
+  value: {{ required "secret.db.host must be set when deployment.db.enabled is false" $root.Values.secret.db.host | quote }}
+  {{- end }}
+{{- end }}
+
+{{/*
+Render a standardized DB port env var.
+Usage: include "supabase.db.portEnv" (dict "root" . "name" "DB_PORT")
+*/}}
+{{- define "supabase.db.portEnv" -}}
+{{- $root := .root -}}
+- name: {{ .name }}
+  {{- if and (not $root.Values.deployment.db.enabled) $root.Values.secret.db.secretRef (hasKey (default (dict) $root.Values.secret.db.secretRefKey) "port") }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "supabase.secret.db.name" $root }}
+      key: {{ include "supabase.secret.db.key.port" $root }}
+  {{- else if and (not $root.Values.deployment.db.enabled) $root.Values.secret.db.port }}
+  value: {{ $root.Values.secret.db.port | quote }}
+  {{- else if $root.Values.deployment.db.enabled }}
+  value: {{ $root.Values.service.db.port | quote }}
+  {{- else }}
+  value: {{ required "secret.db.port must be set when deployment.db.enabled is false" $root.Values.secret.db.port | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/supabase/templates/db/init-external-job.yaml
+++ b/charts/supabase/templates/db/init-external-job.yaml
@@ -56,28 +56,8 @@ spec:
 
               echo "=== External database initialization complete ==="
           env:
-            - name: DB_HOST
-              {{- if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "host") }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.host" . }}
-              {{- else if .Values.secret.db.host }}
-              value: {{ .Values.secret.db.host | quote }}
-              {{- else }}
-              value: {{ .Values.environment.auth.DB_HOST | default "" | quote }}
-              {{- end }}
-            - name: DB_PORT
-              {{- if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "port") }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.port" . }}
-              {{- else if .Values.secret.db.port }}
-              value: {{ .Values.secret.db.port | quote }}
-              {{- else }}
-              value: {{ .Values.environment.auth.DB_PORT | default "5432" | quote }}
-              {{- end }}
+            {{- include "supabase.db.hostEnv" (dict "root" . "name" "DB_HOST") | nindent 12 }}
+            {{- include "supabase.db.portEnv" (dict "root" . "name" "DB_PORT") | nindent 12 }}
             - name: DB_USER
               {{- if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "username") }}
               valueFrom:

--- a/charts/supabase/templates/functions/deployment.yaml
+++ b/charts/supabase/templates/functions/deployment.yaml
@@ -44,8 +44,10 @@ spec:
           {{- end }}
           env:
             {{- range $key, $value := .Values.environment.functions }}
+            {{- if and (ne $key "DB_HOST") (ne $key "DB_PORT") }}
             - name: {{ $key }}
               value: {{ $value | quote }}
+            {{- end }}
             {{- end }}
 
             {{- if .Values.deployment.kong.enabled }}
@@ -53,12 +55,8 @@ spec:
               value: http://{{ include "supabase.kong.fullname" . }}:{{ .Values.service.kong.port }}
             {{- end }}
 
-            - name: DB_HOSTNAME
-              {{- if .Values.deployment.db.enabled }}
-              value: {{ include "supabase.db.fullname" . }}
-              {{- else }}
-              value: $(DB_HOST)
-              {{- end }}
+            {{- include "supabase.db.hostEnv" (dict "root" . "name" "DB_HOSTNAME") | nindent 12 }}
+            {{- include "supabase.db.portEnv" (dict "root" . "name" "DB_PORT") | nindent 12 }}
             - name: DB_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/supabase/templates/meta/deployment.yaml
+++ b/charts/supabase/templates/meta/deployment.yaml
@@ -36,34 +36,13 @@ spec:
           imagePullPolicy: {{ .Values.image.meta.pullPolicy }}
           env:
             {{- range $key, $value := .Values.environment.meta }}
-            {{- if not (and (not $.Values.deployment.db.enabled) (or (and (eq $key "DB_HOST") (or (and $.Values.secret.db.secretRef (hasKey (default (dict) $.Values.secret.db.secretRefKey) "host")) $.Values.secret.db.host)) (and (eq $key "DB_PORT") (or (and $.Values.secret.db.secretRef (hasKey (default (dict) $.Values.secret.db.secretRefKey) "port")) $.Values.secret.db.port)))) }}
+            {{- if and (ne $key "DB_HOST") (ne $key "DB_PORT") }}
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
             {{- end }}
-            {{- if .Values.deployment.db.enabled }}
-            - name: DB_HOST
-              value: {{ include "supabase.db.fullname" . }}
-            {{- else if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "host") }}
-            - name: DB_HOST
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.host" . }}
-            {{- else if .Values.secret.db.host }}
-            - name: DB_HOST
-              value: {{ .Values.secret.db.host | quote }}
-            {{- end }}
-            {{- if and (not .Values.deployment.db.enabled) .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "port") }}
-            - name: DB_PORT
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.port" . }}
-            {{- else if and (not .Values.deployment.db.enabled) .Values.secret.db.port }}
-            - name: DB_PORT
-              value: {{ .Values.secret.db.port | quote }}
-            {{- end }}
+            {{- include "supabase.db.hostEnv" (dict "root" . "name" "DB_HOST") | nindent 12 }}
+            {{- include "supabase.db.portEnv" (dict "root" . "name" "DB_PORT") | nindent 12 }}
             - name: DB_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/supabase/templates/realtime/deployment.yaml
+++ b/charts/supabase/templates/realtime/deployment.yaml
@@ -33,30 +33,8 @@ spec:
           image: "{{ .Values.image.initDb.repository }}:{{ .Values.image.initDb.tag }}"
           imagePullPolicy: {{ .Values.image.initDb.pullPolicy }}
           env:
-            - name: DB_HOST
-              {{- if .Values.deployment.db.enabled }}
-              value: {{ include "supabase.db.fullname" . | quote }}
-              {{- else if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "host") }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.host" . }}
-              {{- else if .Values.secret.db.host }}
-              value: {{ .Values.secret.db.host | quote }}
-              {{- else }}
-              value: {{ .Values.environment.realtime.DB_HOST | quote }}
-              {{- end }}
-            - name: DB_PORT
-              {{- if and (not .Values.deployment.db.enabled) .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "port") }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.port" . }}
-              {{- else if and (not .Values.deployment.db.enabled) .Values.secret.db.port }}
-              value: {{ .Values.secret.db.port | quote }}
-              {{- else }}
-              value: {{ .Values.environment.realtime.DB_PORT | quote }}
-              {{- end }}
+            {{- include "supabase.db.hostEnv" (dict "root" . "name" "DB_HOST") | nindent 12 }}
+            {{- include "supabase.db.portEnv" (dict "root" . "name" "DB_PORT") | nindent 12 }}
           command: ["/bin/sh", "-c"]
           args:
             - |
@@ -75,34 +53,13 @@ spec:
           args: ["-c", "/app/bin/migrate && /app/bin/realtime eval 'Realtime.Release.seeds(Realtime.Repo)' && /app/bin/server"]
           env:
             {{- range $key, $value := .Values.environment.realtime }}
-            {{- if not (and (not $.Values.deployment.db.enabled) (or (and (eq $key "DB_HOST") (or (and $.Values.secret.db.secretRef (hasKey (default (dict) $.Values.secret.db.secretRefKey) "host")) $.Values.secret.db.host)) (and (eq $key "DB_PORT") (or (and $.Values.secret.db.secretRef (hasKey (default (dict) $.Values.secret.db.secretRefKey) "port")) $.Values.secret.db.port)))) }}
+            {{- if and (ne $key "DB_HOST") (ne $key "DB_PORT") }}
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
             {{- end }}
-            {{- if .Values.deployment.db.enabled }}
-            - name: DB_HOST
-              value: {{ include "supabase.db.fullname" . }}
-            {{- else if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "host") }}
-            - name: DB_HOST
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.host" . }}
-            {{- else if .Values.secret.db.host }}
-            - name: DB_HOST
-              value: {{ .Values.secret.db.host | quote }}
-            {{- end }}
-            {{- if and (not .Values.deployment.db.enabled) .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "port") }}
-            - name: DB_PORT
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.port" . }}
-            {{- else if and (not .Values.deployment.db.enabled) .Values.secret.db.port }}
-            - name: DB_PORT
-              value: {{ .Values.secret.db.port | quote }}
-            {{- end }}
+            {{- include "supabase.db.hostEnv" (dict "root" . "name" "DB_HOST") | nindent 12 }}
+            {{- include "supabase.db.portEnv" (dict "root" . "name" "DB_PORT") | nindent 12 }}
             - name: SELF_HOST_TENANT_NAME
               value: {{ include "supabase.realtime.fullname" . }}
             - name: DB_PASSWORD

--- a/charts/supabase/templates/rest/deployment.yaml
+++ b/charts/supabase/templates/rest/deployment.yaml
@@ -33,30 +33,8 @@ spec:
           image: "{{ .Values.image.initDb.repository }}:{{ .Values.image.initDb.tag }}"
           imagePullPolicy: {{ .Values.image.initDb.pullPolicy }}
           env:
-            - name: DB_HOST
-              {{- if .Values.deployment.db.enabled }}
-              value: {{ include "supabase.db.fullname" . | quote }}
-              {{- else if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "host") }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.host" . }}
-              {{- else if .Values.secret.db.host }}
-              value: {{ .Values.secret.db.host | quote }}
-              {{- else }}
-              value: {{ .Values.environment.rest.DB_HOST | quote }}
-              {{- end }}
-            - name: DB_PORT
-              {{- if and (not .Values.deployment.db.enabled) .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "port") }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.port" . }}
-              {{- else if and (not .Values.deployment.db.enabled) .Values.secret.db.port }}
-              value: {{ .Values.secret.db.port | quote }}
-              {{- else }}
-              value: {{ .Values.environment.rest.DB_PORT | quote }}
-              {{- end }}
+            {{- include "supabase.db.hostEnv" (dict "root" . "name" "DB_HOST") | nindent 12 }}
+            {{- include "supabase.db.portEnv" (dict "root" . "name" "DB_PORT") | nindent 12 }}
           command: ["/bin/sh", "-c"]
           args:
             - |
@@ -73,34 +51,13 @@ spec:
           imagePullPolicy: {{ .Values.image.rest.pullPolicy }}
           env:
             {{- range $key, $value := .Values.environment.rest }}
-            {{- if not (and (not $.Values.deployment.db.enabled) (or (and (eq $key "DB_HOST") (or (and $.Values.secret.db.secretRef (hasKey (default (dict) $.Values.secret.db.secretRefKey) "host")) $.Values.secret.db.host)) (and (eq $key "DB_PORT") (or (and $.Values.secret.db.secretRef (hasKey (default (dict) $.Values.secret.db.secretRefKey) "port")) $.Values.secret.db.port)))) }}
+            {{- if and (ne $key "DB_HOST") (ne $key "DB_PORT") }}
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
             {{- end }}
-            {{- if .Values.deployment.db.enabled }}
-            - name: DB_HOST
-              value: {{ include "supabase.db.fullname" . }}
-            {{- else if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "host") }}
-            - name: DB_HOST
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.host" . }}
-            {{- else if .Values.secret.db.host }}
-            - name: DB_HOST
-              value: {{ .Values.secret.db.host | quote }}
-            {{- end }}
-            {{- if and (not .Values.deployment.db.enabled) .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "port") }}
-            - name: DB_PORT
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.port" . }}
-            {{- else if and (not .Values.deployment.db.enabled) .Values.secret.db.port }}
-            - name: DB_PORT
-              value: {{ .Values.secret.db.port | quote }}
-            {{- end }}
+            {{- include "supabase.db.hostEnv" (dict "root" . "name" "DB_HOST") | nindent 12 }}
+            {{- include "supabase.db.portEnv" (dict "root" . "name" "DB_PORT") | nindent 12 }}
             - name: DB_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/supabase/templates/storage/deployment.yaml
+++ b/charts/supabase/templates/storage/deployment.yaml
@@ -34,30 +34,8 @@ spec:
           image: "{{ .Values.image.initDb.repository }}:{{ .Values.image.initDb.tag }}"
           imagePullPolicy: {{ .Values.image.initDb.pullPolicy }}
           env:
-            - name: DB_HOST
-              {{- if .Values.deployment.db.enabled }}
-              value: {{ include "supabase.db.fullname" . | quote }}
-              {{- else if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "host") }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.host" . }}
-              {{- else if .Values.secret.db.host }}
-              value: {{ .Values.secret.db.host | quote }}
-              {{- else }}
-              value: {{ .Values.environment.storage.DB_HOST | quote }}
-              {{- end }}
-            - name: DB_PORT
-              {{- if and (not .Values.deployment.db.enabled) .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "port") }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.port" . }}
-              {{- else if and (not .Values.deployment.db.enabled) .Values.secret.db.port }}
-              value: {{ .Values.secret.db.port | quote }}
-              {{- else }}
-              value: {{ .Values.environment.storage.DB_PORT | quote }}
-              {{- end }}
+            {{- include "supabase.db.hostEnv" (dict "root" . "name" "DB_HOST") | nindent 12 }}
+            {{- include "supabase.db.portEnv" (dict "root" . "name" "DB_PORT") | nindent 12 }}
           command: ["/bin/sh", "-c"]
           args:
             - |
@@ -109,7 +87,7 @@ spec:
           imagePullPolicy: {{ .Values.image.storage.pullPolicy }}
           env:
             {{- range $key, $value := .Values.environment.storage }}
-            {{- if and (ne $key "AWS_ACCESS_KEY_ID") (ne $key "AWS_SECRET_ACCESS_KEY") (ne $key "STORAGE_BACKEND") (not (and (not $.Values.deployment.db.enabled) (or (and (eq $key "DB_HOST") (or (and $.Values.secret.db.secretRef (hasKey (default (dict) $.Values.secret.db.secretRefKey) "host")) $.Values.secret.db.host)) (and (eq $key "DB_PORT") (or (and $.Values.secret.db.secretRef (hasKey (default (dict) $.Values.secret.db.secretRefKey) "port")) $.Values.secret.db.port))))) }}
+            {{- if and (ne $key "AWS_ACCESS_KEY_ID") (ne $key "AWS_SECRET_ACCESS_KEY") (ne $key "STORAGE_BACKEND") (ne $key "DB_HOST") (ne $key "DB_PORT") }}
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
@@ -149,29 +127,8 @@ spec:
                   {{- end }}
             {{- end }}
 
-            {{- if .Values.deployment.db.enabled }}
-            - name: DB_HOST
-              value: {{ include "supabase.db.fullname" . }}
-            {{- else if and .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "host") }}
-            - name: DB_HOST
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.host" . }}
-            {{- else if .Values.secret.db.host }}
-            - name: DB_HOST
-              value: {{ .Values.secret.db.host | quote }}
-            {{- end }}
-            {{- if and (not .Values.deployment.db.enabled) .Values.secret.db.secretRef (hasKey (default (dict) .Values.secret.db.secretRefKey) "port") }}
-            - name: DB_PORT
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.db.name" . }}
-                  key: {{ include "supabase.secret.db.key.port" . }}
-            {{- else if and (not .Values.deployment.db.enabled) .Values.secret.db.port }}
-            - name: DB_PORT
-              value: {{ .Values.secret.db.port | quote }}
-            {{- end }}
+            {{- include "supabase.db.hostEnv" (dict "root" . "name" "DB_HOST") | nindent 12 }}
+            {{- include "supabase.db.portEnv" (dict "root" . "name" "DB_PORT") | nindent 12 }}
             {{- if .Values.deployment.rest.enabled }}
             - name: POSTGREST_URL
               value: http://{{ include "supabase.rest.fullname" . }}:{{ .Values.service.rest.port }}

--- a/charts/supabase/templates/test/db.yaml
+++ b/charts/supabase/templates/test/db.yaml
@@ -19,14 +19,8 @@ spec:
               pg_isready -h $(DB_HOST) -p $(DB_PORT) -U postgres || $(echo "\e[0;31mFailed to connect to the database." && exit 1)
               echo "Database is ready"
           env:
-            - name: DB_HOST
-              {{- if .Values.deployment.db.enabled }}
-              value: {{ include "supabase.db.fullname" . | quote }}
-              {{- else }}
-              value: {{ .Values.environment.auth.DB_HOST | quote }}
-              {{- end }}
-            - name: DB_PORT
-              value: {{ .Values.environment.auth.DB_PORT | quote }}
+            {{- include "supabase.db.hostEnv" (dict "root" . "name" "DB_HOST") | nindent 12 }}
+            {{- include "supabase.db.portEnv" (dict "root" . "name" "DB_PORT") | nindent 12 }}
           image: postgres:15-alpine
           imagePullPolicy: IfNotPresent
           name: test-db

--- a/charts/supabase/values.yaml
+++ b/charts/supabase/values.yaml
@@ -89,7 +89,7 @@ secret:
     database: "postgres"
 
     ## External database host/port (used when deployment.db.enabled is false).
-    ## Leave empty to fall back to environment.<service>.DB_HOST / DB_PORT.
+    ## Host and port are required when using an external database.
     ## Ignored when deployment.db.enabled is true (internal DB service is used).
     host: ""
     port: ""
@@ -536,7 +536,6 @@ environment:
     LOGFLARE_NODE_HOST: 127.0.0.1
     DB_USERNAME: supabase_admin
     DB_DATABASE: _supabase
-    DB_PORT: 5432
     DB_DRIVER: postgresql
     DB_SCHEMA: _analytics
     POSTGRES_BACKEND_SCHEMA: _analytics
@@ -546,7 +545,6 @@ environment:
 
   auth:
     DB_USER: supabase_auth_admin
-    DB_PORT: 5432
     DB_DRIVER: postgres
     ## SSL mode options: disable, allow, prefer, require, verify-ca, verify-full
     DB_SSL: disable
@@ -603,7 +601,6 @@ environment:
 
   functions:
     DB_USERNAME: postgres
-    DB_PORT: 5432
     DB_DRIVER: postgresql
     ## SSL mode options: disable, allow, prefer, require, verify-ca, verify-full
     DB_SSL: disable
@@ -627,7 +624,6 @@ environment:
 
   meta:
     DB_USER: supabase_admin
-    DB_PORT: 5432
     DB_DRIVER: postgres
     ## SSL mode options: disable, allow, prefer, require, verify-ca, verify-full
     DB_SSL: disable
@@ -637,7 +633,6 @@ environment:
 
   realtime:
     DB_USER: supabase_admin
-    DB_PORT: 5432
     ## Set to true to enforce TLS connections to Postgres
     DB_SSL: false
     PORT: "4000"
@@ -655,7 +650,6 @@ environment:
 
   rest:
     DB_USER: authenticator
-    DB_PORT: 5432
     DB_DRIVER: postgres
     ## SSL mode options: disable, allow, prefer, require, verify-ca, verify-full
     DB_SSL: disable
@@ -666,7 +660,6 @@ environment:
 
   storage:
     DB_USER: supabase_storage_admin
-    DB_PORT: 5432
     DB_DRIVER: postgres
     ## SSL mode options: disable, allow, prefer, require, verify-ca, verify-full
     DB_SSL: disable


### PR DESCRIPTION
## What kind of change does this PR introduce?
Refactor / bug fix (configuration hardening) for the Helm chart database configuration flow.
## What is the current behavior?
Database host/port resolution is inconsistent across services:
- some templates read `DB_HOST`/`DB_PORT` from `environment.<service>.*`
- others override from `secret.db.*` conditionally
- functions used a different host variable flow (`DB_HOSTNAME`)
- this allows duplicated/conflicting config paths and weak standardization for external DB setups.
## What is the new behavior?
Database host/port resolution is now fully standardized:
- `DB_HOST` and `DB_PORT` are rendered through shared helpers in `templates/db/_helpers.tpl`
- for internal DB: host uses `supabase.db.fullname`, port uses `service.db.port`
- for external DB: host/port come only from `secret.db.host`/`secret.db.port` or mapped keys via `secret.db.secretRefKey`
- removed fallback to `environment.<service>.DB_HOST` and `environment.<service>.DB_PORT`
- removed `DB_PORT` defaults from `values.yaml` service environment blocks
- Helm now fails fast with clear `required` errors when external DB host/port are missing.
## Additional context
- This change reduces configuration ambiguity and enforces a single source of truth for DB connectivity.
- `helm lint charts/supabase` passes after the refactor.
- Users configuring external DB must ensure both `secret.db.host` and `secret.db.port` (or equivalent secretRef mappings) are set.