### PR TITLE
chore(db) add serviceName parameter

### DIFF
--- a/charts/supabase/templates/db/statefulset.yaml
+++ b/charts/supabase/templates/db/statefulset.yaml
@@ -12,6 +12,7 @@ spec:
   selector:
     matchLabels:
       {{- include "supabase.db.selectorLabels" . | nindent 6 }}
+  serviceName: {{ include "supabase.db.fullname" . }}
   template:
     metadata:
       {{- with .Values.deployment.db.podAnnotations }}


### PR DESCRIPTION
## What kind of change does this PR introduce?

#181 
A little chore specifying serviceName on the database statefulset to comply with api validations.

## What is the current behavior?

serviceName is not defined explicitly

## What is the new behavior?

serviceName being set which does not provide any real benefit except for passing validations

