### PR TITLE
chore(charts): standardize workload template ordering and deployment defaults

### DIFF
--- a/charts/supabase/templates/analytics/deployment.yaml
+++ b/charts/supabase/templates/analytics/deployment.yaml
@@ -3,8 +3,13 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "supabase.analytics.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.deployment.analytics.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.autoscaling.analytics.enabled }}
   replicas: {{ .Values.deployment.analytics.replicaCount }}
@@ -14,20 +19,42 @@ spec:
       {{- include "supabase.analytics.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      labels:
+        {{- include "supabase.analytics.selectorLabels" . | nindent 8 }}
       {{- with .Values.deployment.analytics.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      labels:
-        {{- include "supabase.analytics.selectorLabels" . | nindent 8 }}
     spec:
+      serviceAccountName: {{ include "supabase.analytics.serviceAccountName" . }}
+      {{- if hasKey .Values.deployment.analytics "automountServiceAccountToken" }}
+      automountServiceAccountToken: {{ .Values.deployment.analytics.automountServiceAccountToken }}
+      {{- end }}
+      restartPolicy: Always
+      {{- if hasKey .Values.deployment.analytics "terminationGracePeriodSeconds" }}
+      terminationGracePeriodSeconds: {{ .Values.deployment.analytics.terminationGracePeriodSeconds }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.deployment.analytics.podSecurityContext | nindent 8 }}
       {{- with .Values.image.analytics.pullSecrets}}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "supabase.analytics.serviceAccountName" . }}
-      securityContext:
-        {{- toYaml .Values.deployment.analytics.podSecurityContext | nindent 8 }}
+      {{- with .Values.deployment.analytics.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.analytics.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.analytics.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.analytics.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       initContainers:
         - name: init-db
           image: "{{ .Values.image.initDb.repository }}:{{ .Values.image.initDb.tag }}"
@@ -45,10 +72,11 @@ spec:
             - echo "Database is ready"
       containers:
         - name: {{ include "supabase.analytics.name" $ }}
-          securityContext:
-            {{- toYaml .Values.deployment.analytics.securityContext | nindent 12 }}
           image: "{{ .Values.image.analytics.repository }}:{{ .Values.image.analytics.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.analytics.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.service.analytics.port }}
+              protocol: TCP
           env:
             {{- range $key, $value := .Values.environment.analytics }}
             {{- if and (ne $key "DB_HOST") (ne $key "DB_PORT") }}
@@ -87,17 +115,14 @@ spec:
             - name: POSTGRES_BACKEND_URL
               value: $(DB_DRIVER)://$(DB_USERNAME):$(DB_PASSWORD_ENC)@$(DB_HOSTNAME):$(DB_PORT)/$(DB_DATABASE)
             {{- end }}
-          {{- with .Values.deployment.analytics.livenessProbe }}
-          livenessProbe:
+          {{- with .Values.deployment.analytics.envFrom }}
+          envFrom:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.deployment.analytics.readinessProbe }}
-          readinessProbe:
+          {{- with .Values.deployment.analytics.resources }}
+          resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          ports:
-            - containerPort: {{ .Values.service.analytics.port }}
-              protocol: TCP
           {{- if or (.Values.bigQuery.enabled) (.Values.deployment.analytics.volumes) }}
           volumeMounts:
             {{- with .Values.deployment.analytics.volumeMounts }}
@@ -109,10 +134,24 @@ spec:
               subPath: {{ include "supabase.secret.bigquery.key.gcloudJson" . }}
             {{- end }}
           {{- end }}
-          {{- with .Values.deployment.analytics.resources }}
-          resources:
+          {{- with .Values.deployment.analytics.livenessProbe }}
+          livenessProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.deployment.analytics.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.deployment.analytics.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.deployment.analytics.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.deployment.analytics.securityContext | nindent 12 }}
       {{- if or (.Values.bigQuery.enabled) (.Values.deployment.analytics.volumes) }}
       volumes:
         {{- with .Values.deployment.analytics.volumes }}
@@ -123,17 +162,5 @@ spec:
           secret:
             secretName: {{ include "supabase.secret.bigquery.name" . }}
         {{- end }}
-      {{- end }}
-      {{- with .Values.deployment.analytics.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.deployment.analytics.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.deployment.analytics.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/charts/supabase/templates/analytics/deployment.yaml
+++ b/charts/supabase/templates/analytics/deployment.yaml
@@ -27,13 +27,9 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ include "supabase.analytics.serviceAccountName" . }}
-      {{- if hasKey .Values.deployment.analytics "automountServiceAccountToken" }}
       automountServiceAccountToken: {{ .Values.deployment.analytics.automountServiceAccountToken }}
-      {{- end }}
       restartPolicy: Always
-      {{- if hasKey .Values.deployment.analytics "terminationGracePeriodSeconds" }}
       terminationGracePeriodSeconds: {{ .Values.deployment.analytics.terminationGracePeriodSeconds }}
-      {{- end }}
       securityContext:
         {{- toYaml .Values.deployment.analytics.podSecurityContext | nindent 8 }}
       {{- with .Values.image.analytics.pullSecrets}}

--- a/charts/supabase/templates/auth/deployment.yaml
+++ b/charts/supabase/templates/auth/deployment.yaml
@@ -27,13 +27,9 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ include "supabase.auth.serviceAccountName" . }}
-      {{- if hasKey .Values.deployment.auth "automountServiceAccountToken" }}
       automountServiceAccountToken: {{ .Values.deployment.auth.automountServiceAccountToken }}
-      {{- end }}
       restartPolicy: Always
-      {{- if hasKey .Values.deployment.auth "terminationGracePeriodSeconds" }}
       terminationGracePeriodSeconds: {{ .Values.deployment.auth.terminationGracePeriodSeconds }}
-      {{- end }}
       securityContext:
         {{- toYaml .Values.deployment.auth.podSecurityContext | nindent 8 }}
       {{- with .Values.image.auth.pullSecrets}}

--- a/charts/supabase/templates/auth/deployment.yaml
+++ b/charts/supabase/templates/auth/deployment.yaml
@@ -3,8 +3,13 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "supabase.auth.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.deployment.auth.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.autoscaling.auth.enabled }}
   replicas: {{ .Values.deployment.auth.replicaCount }}
@@ -14,20 +19,42 @@ spec:
       {{- include "supabase.auth.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      labels:
+        {{- include "supabase.auth.selectorLabels" . | nindent 8 }}
       {{- with .Values.deployment.auth.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      labels:
-        {{- include "supabase.auth.selectorLabels" . | nindent 8 }}
     spec:
+      serviceAccountName: {{ include "supabase.auth.serviceAccountName" . }}
+      {{- if hasKey .Values.deployment.auth "automountServiceAccountToken" }}
+      automountServiceAccountToken: {{ .Values.deployment.auth.automountServiceAccountToken }}
+      {{- end }}
+      restartPolicy: Always
+      {{- if hasKey .Values.deployment.auth "terminationGracePeriodSeconds" }}
+      terminationGracePeriodSeconds: {{ .Values.deployment.auth.terminationGracePeriodSeconds }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.deployment.auth.podSecurityContext | nindent 8 }}
       {{- with .Values.image.auth.pullSecrets}}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "supabase.auth.serviceAccountName" . }}
-      securityContext:
-        {{- toYaml .Values.deployment.auth.podSecurityContext | nindent 8 }}
+      {{- with .Values.deployment.auth.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.auth.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.auth.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.auth.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       initContainers:
         - name: init-db
           image: "{{ .Values.image.initDb.repository }}:{{ .Values.image.initDb.tag }}"
@@ -45,10 +72,12 @@ spec:
             - echo "Database is ready"
       containers:
         - name: {{ include "supabase.auth.name" $ }}
-          securityContext:
-            {{- toYaml .Values.deployment.auth.securityContext | nindent 12 }}
           image: "{{ .Values.image.auth.repository }}:{{ .Values.image.auth.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.auth.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 9999
+              protocol: TCP
           env:
             {{- range $key, $value := .Values.environment.auth }}
             {{- if and (ne $key "DB_HOST") (ne $key "DB_PORT") }}
@@ -107,18 +136,6 @@ spec:
           envFrom:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.deployment.auth.livenessProbe }}
-          livenessProbe:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- with .Values.deployment.auth.readinessProbe }}
-          readinessProbe:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          ports:
-            - name: http
-              containerPort: 9999
-              protocol: TCP
           {{- with .Values.deployment.auth.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -127,20 +144,26 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.deployment.auth.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.deployment.auth.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.deployment.auth.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.deployment.auth.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.deployment.auth.securityContext | nindent 12 }}
       {{- with .Values.deployment.auth.volumes }}
       volumes:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.deployment.auth.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.deployment.auth.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.deployment.auth.tolerations }}
-      tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/charts/supabase/templates/db/statefulset.yaml
+++ b/charts/supabase/templates/db/statefulset.yaml
@@ -28,13 +28,9 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ include "supabase.db.serviceAccountName" . }}
-      {{- if hasKey .Values.deployment.db "automountServiceAccountToken" }}
       automountServiceAccountToken: {{ .Values.deployment.db.automountServiceAccountToken }}
-      {{- end }}
       restartPolicy: Always
-      {{- if hasKey .Values.deployment.db "terminationGracePeriodSeconds" }}
       terminationGracePeriodSeconds: {{ .Values.deployment.db.terminationGracePeriodSeconds }}
-      {{- end }}
       securityContext:
         {{- toYaml .Values.deployment.db.podSecurityContext | nindent 8 }}
       {{- with .Values.image.db.pullSecrets}}

--- a/charts/supabase/templates/db/statefulset.yaml
+++ b/charts/supabase/templates/db/statefulset.yaml
@@ -3,8 +3,13 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "supabase.db.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.deployment.db.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.autoscaling.db.enabled }}
   replicas: {{ .Values.deployment.db.replicaCount }}
@@ -15,20 +20,42 @@ spec:
   serviceName: {{ include "supabase.db.fullname" . }}
   template:
     metadata:
+      labels:
+        {{- include "supabase.db.selectorLabels" . | nindent 8 }}
       {{- with .Values.deployment.db.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      labels:
-        {{- include "supabase.db.selectorLabels" . | nindent 8 }}
     spec:
+      serviceAccountName: {{ include "supabase.db.serviceAccountName" . }}
+      {{- if hasKey .Values.deployment.db "automountServiceAccountToken" }}
+      automountServiceAccountToken: {{ .Values.deployment.db.automountServiceAccountToken }}
+      {{- end }}
+      restartPolicy: Always
+      {{- if hasKey .Values.deployment.db "terminationGracePeriodSeconds" }}
+      terminationGracePeriodSeconds: {{ .Values.deployment.db.terminationGracePeriodSeconds }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.deployment.db.podSecurityContext | nindent 8 }}
       {{- with .Values.image.db.pullSecrets}}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "supabase.db.serviceAccountName" . }}
-      securityContext:
-        {{- toYaml .Values.deployment.db.podSecurityContext | nindent 8 }}
+      {{- with .Values.deployment.db.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.db.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.db.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.db.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       initContainers:
         - name: init-db
           image: "{{ .Values.image.db.repository }}:{{ .Values.image.db.tag | default .Chart.AppVersion }}"
@@ -62,14 +89,12 @@ spec:
       {{- end }}
       containers:
         - name: {{ include "supabase.db.name" $ }}
-          securityContext:
-            {{- toYaml .Values.deployment.db.securityContext | nindent 12 }}
           image: "{{ .Values.image.db.repository }}:{{ .Values.image.db.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.db.pullPolicy }}
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh", "-c", "pg_ctl -D /var/lib/postgres/data -w -t 60 -m fast stop"]
+          ports:
+            - name: http
+              containerPort: 5432
+              protocol: TCP
           env:
             {{- range $key, $value := .Values.environment.db }}
             - name: {{ $key }}
@@ -100,18 +125,14 @@ spec:
                 secretKeyRef:
                   name: {{ include "supabase.secret.jwt.name" . }}
                   key: {{ include "supabase.secret.jwt.key.secret" . }}
-          {{- with .Values.deployment.db.livenessProbe }}
-          livenessProbe:
+          {{- with .Values.deployment.db.envFrom }}
+          envFrom:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.deployment.db.readinessProbe }}
-          readinessProbe:
+          {{- with .Values.deployment.db.resources }}
+          resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          ports:
-            - name: http
-              containerPort: 5432
-              protocol: TCP
           volumeMounts:
             - mountPath: /docker-entrypoint-initdb.d
               name: initdb-scripts-data
@@ -123,10 +144,27 @@ spec:
               name: postgres-volume
               subPath: postgres-data
             {{- end }}
-          {{- with .Values.deployment.db.resources }}
-          resources:
+          {{- with .Values.deployment.db.livenessProbe }}
+          livenessProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.deployment.db.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.deployment.db.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "pg_ctl -D /var/lib/postgres/data -w -t 60 -m fast stop"]
+          {{- with .Values.deployment.db.lifecycle }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.deployment.db.securityContext | nindent 12 }}
       volumes:
         - name: initdb-scripts-data
           emptyDir:
@@ -145,16 +183,4 @@ spec:
           persistentVolumeClaim:
             claimName: {{ include "supabase.pvc.name" (dict "root" $ "name" "db") }}
         {{- end }}
-      {{- with .Values.deployment.db.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.deployment.db.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.deployment.db.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
 {{- end }}

--- a/charts/supabase/templates/functions/deployment.yaml
+++ b/charts/supabase/templates/functions/deployment.yaml
@@ -27,13 +27,9 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ include "supabase.functions.serviceAccountName" . }}
-      {{- if hasKey .Values.deployment.functions "automountServiceAccountToken" }}
       automountServiceAccountToken: {{ .Values.deployment.functions.automountServiceAccountToken }}
-      {{- end }}
       restartPolicy: Always
-      {{- if hasKey .Values.deployment.functions "terminationGracePeriodSeconds" }}
       terminationGracePeriodSeconds: {{ .Values.deployment.functions.terminationGracePeriodSeconds }}
-      {{- end }}
       securityContext:
         {{- toYaml .Values.deployment.functions.podSecurityContext | nindent 8 }}
       {{- with .Values.image.functions.pullSecrets}}

--- a/charts/supabase/templates/functions/deployment.yaml
+++ b/charts/supabase/templates/functions/deployment.yaml
@@ -3,8 +3,13 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "supabase.functions.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.deployment.functions.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.autoscaling.functions.enabled }}
   replicas: {{ .Values.deployment.functions.replicaCount }}
@@ -14,34 +19,50 @@ spec:
       {{- include "supabase.functions.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      labels:
+        {{- include "supabase.functions.selectorLabels" . | nindent 8 }}
       {{- with .Values.deployment.functions.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      labels:
-        {{- include "supabase.functions.selectorLabels" . | nindent 8 }}
     spec:
+      serviceAccountName: {{ include "supabase.functions.serviceAccountName" . }}
+      {{- if hasKey .Values.deployment.functions "automountServiceAccountToken" }}
+      automountServiceAccountToken: {{ .Values.deployment.functions.automountServiceAccountToken }}
+      {{- end }}
+      restartPolicy: Always
+      {{- if hasKey .Values.deployment.functions "terminationGracePeriodSeconds" }}
+      terminationGracePeriodSeconds: {{ .Values.deployment.functions.terminationGracePeriodSeconds }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.deployment.functions.podSecurityContext | nindent 8 }}
       {{- with .Values.image.functions.pullSecrets}}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "supabase.functions.serviceAccountName" . }}
-      securityContext:
-        {{- toYaml .Values.deployment.functions.podSecurityContext | nindent 8 }}
+      {{- with .Values.deployment.functions.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.functions.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.functions.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.functions.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       containers:
-        - args:
+        - name: {{ include "supabase.functions.name" $ }}
+          image: "{{ .Values.image.functions.repository }}:{{ .Values.image.functions.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.functions.pullPolicy }}
+          args:
             - start
             - --main-service
             - /home/deno/functions/main
-          name: {{ include "supabase.functions.name" $ }}
-          securityContext:
-            {{- toYaml .Values.deployment.functions.securityContext | nindent 12 }}
-          image: "{{ .Values.image.functions.repository }}:{{ .Values.image.functions.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.functions.pullPolicy }}
-          {{- if .Values.deployment.functions.envFrom }}
-          envFrom:
-            {{- toYaml .Values.deployment.functions.envFrom | nindent 12 }}
-          {{- end }}
           env:
             {{- range $key, $value := .Values.environment.functions }}
             {{- if and (ne $key "DB_HOST") (ne $key "DB_PORT") }}
@@ -107,12 +128,12 @@ spec:
               value: '{"default":"$(SUPABASE_SECRET_KEY)"}'
             - name: SUPABASE_DB_URL
               value: $(DB_DRIVER)://$(DB_USERNAME):$(DB_PASSWORD_ENC)@$(DB_HOSTNAME):$(DB_PORT)/$(DB_DATABASE)?search_path=auth&sslmode=$(DB_SSL)
-          {{- with .Values.deployment.functions.livenessProbe }}
-          livenessProbe:
-            {{- toYaml . | nindent 12 }}
+          {{- if .Values.deployment.functions.envFrom }}
+          envFrom:
+            {{- toYaml .Values.deployment.functions.envFrom | nindent 12 }}
           {{- end }}
-          {{- with .Values.deployment.functions.readinessProbe }}
-          readinessProbe:
+          {{- with .Values.deployment.functions.resources }}
+          resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
@@ -130,10 +151,24 @@ spec:
             - mountPath: /home/deno/functions/main/index.ts
               name: functions-main
               subPath: index.ts
-          {{- with .Values.deployment.functions.resources }}
-          resources:
+          {{- with .Values.deployment.functions.livenessProbe }}
+          livenessProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.deployment.functions.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.deployment.functions.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.deployment.functions.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.deployment.functions.securityContext | nindent 12 }}
       volumes:
         {{- with .Values.deployment.functions.volumes }}
           {{- toYaml . | nindent 8 }}
@@ -151,16 +186,4 @@ spec:
         - name: functions-main
           configMap:
             name: {{ include "supabase.functions.fullname" . }}-main
-      {{- with .Values.deployment.functions.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.deployment.functions.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.deployment.functions.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
 {{- end }}

--- a/charts/supabase/templates/imgproxy/deployment.yaml
+++ b/charts/supabase/templates/imgproxy/deployment.yaml
@@ -3,8 +3,13 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "supabase.imgproxy.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.deployment.imgproxy.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.autoscaling.imgproxy.enabled }}
   replicas: {{ .Values.deployment.imgproxy.replicaCount }}
@@ -14,67 +19,26 @@ spec:
       {{- include "supabase.imgproxy.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      labels:
+        {{- include "supabase.imgproxy.selectorLabels" . | nindent 8 }}
       {{- with .Values.deployment.imgproxy.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      labels:
-        {{- include "supabase.imgproxy.selectorLabels" . | nindent 8 }}
     spec:
+      serviceAccountName: {{ include "supabase.imgproxy.serviceAccountName" . }}
+      {{- if hasKey .Values.deployment.imgproxy "automountServiceAccountToken" }}
+      automountServiceAccountToken: {{ .Values.deployment.imgproxy.automountServiceAccountToken }}
+      {{- end }}
+      restartPolicy: Always
+      {{- if hasKey .Values.deployment.imgproxy "terminationGracePeriodSeconds" }}
+      terminationGracePeriodSeconds: {{ .Values.deployment.imgproxy.terminationGracePeriodSeconds }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.deployment.imgproxy.podSecurityContext | nindent 8 }}
       {{- with .Values.image.imgproxy.pullSecrets}}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
-      {{- end }}
-      serviceAccountName: {{ include "supabase.imgproxy.serviceAccountName" . }}
-      securityContext:
-        {{- toYaml .Values.deployment.imgproxy.podSecurityContext | nindent 8 }}
-      containers:
-        - name: {{ include "supabase.imgproxy.name" $ }}
-          securityContext:
-            {{- toYaml .Values.deployment.imgproxy.securityContext | nindent 12 }}
-          image: "{{ .Values.image.imgproxy.repository }}:{{ .Values.image.imgproxy.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.imgproxy.pullPolicy }}
-          env:
-            {{- range $key, $value := .Values.environment.imgproxy }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
-            {{- end }}
-          {{- with .Values.deployment.imgproxy.livenessProbe }}
-          livenessProbe:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- with .Values.deployment.imgproxy.readinessProbe }}
-          readinessProbe:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          ports:
-            - name: http
-              containerPort: 8080
-              protocol: TCP
-          {{- if or (.Values.persistence.imgproxy.enabled) (.Values.deployment.imgproxy.volumes) }}
-          volumeMounts:
-            {{- with .Values.deployment.imgproxy.volumeMounts }}
-              {{- toYaml . | nindent 12 }}
-            {{- end }}
-            {{- if .Values.persistence.imgproxy.enabled }}
-            - mountPath: /var/lib/storage
-              name: imgproxy-volume
-            {{- end }}
-          {{- end }}
-          {{- with .Values.deployment.imgproxy.resources }}
-          resources:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-      {{- if or (.Values.persistence.imgproxy.enabled) (.Values.deployment.imgproxy.volumes) }}
-      volumes:
-        {{- with .Values.deployment.imgproxy.volumes }}
-          {{- toYaml . | nindent 8 }}
-        {{- end }}
-        {{- if .Values.persistence.imgproxy.enabled }}
-        - name: imgproxy-volume
-          persistentVolumeClaim:
-            claimName: {{ include "supabase.pvc.name" (dict "root" $ "name" "imgproxy") }}
-        {{- end }}
       {{- end }}
       {{- with .Values.deployment.imgproxy.nodeSelector }}
       nodeSelector:
@@ -87,5 +51,68 @@ spec:
       {{- with .Values.deployment.imgproxy.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.imgproxy.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      containers:
+        - name: {{ include "supabase.imgproxy.name" $ }}
+          image: "{{ .Values.image.imgproxy.repository }}:{{ .Values.image.imgproxy.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.imgproxy.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            {{- range $key, $value := .Values.environment.imgproxy }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          {{- with .Values.deployment.imgproxy.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.deployment.imgproxy.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if or (.Values.persistence.imgproxy.enabled) (.Values.deployment.imgproxy.volumes) }}
+          volumeMounts:
+            {{- with .Values.deployment.imgproxy.volumeMounts }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- if .Values.persistence.imgproxy.enabled }}
+            - mountPath: /var/lib/storage
+              name: imgproxy-volume
+            {{- end }}
+          {{- end }}
+          {{- with .Values.deployment.imgproxy.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.deployment.imgproxy.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.deployment.imgproxy.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.deployment.imgproxy.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.deployment.imgproxy.securityContext | nindent 12 }}
+      {{- if or (.Values.persistence.imgproxy.enabled) (.Values.deployment.imgproxy.volumes) }}
+      volumes:
+        {{- with .Values.deployment.imgproxy.volumes }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- if .Values.persistence.imgproxy.enabled }}
+        - name: imgproxy-volume
+          persistentVolumeClaim:
+            claimName: {{ include "supabase.pvc.name" (dict "root" $ "name" "imgproxy") }}
+        {{- end }}
       {{- end }}
 {{- end }}

--- a/charts/supabase/templates/imgproxy/deployment.yaml
+++ b/charts/supabase/templates/imgproxy/deployment.yaml
@@ -27,13 +27,9 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ include "supabase.imgproxy.serviceAccountName" . }}
-      {{- if hasKey .Values.deployment.imgproxy "automountServiceAccountToken" }}
       automountServiceAccountToken: {{ .Values.deployment.imgproxy.automountServiceAccountToken }}
-      {{- end }}
       restartPolicy: Always
-      {{- if hasKey .Values.deployment.imgproxy "terminationGracePeriodSeconds" }}
       terminationGracePeriodSeconds: {{ .Values.deployment.imgproxy.terminationGracePeriodSeconds }}
-      {{- end }}
       securityContext:
         {{- toYaml .Values.deployment.imgproxy.podSecurityContext | nindent 8 }}
       {{- with .Values.image.imgproxy.pullSecrets}}

--- a/charts/supabase/templates/kong/deployment.yaml
+++ b/charts/supabase/templates/kong/deployment.yaml
@@ -3,8 +3,13 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "supabase.kong.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.deployment.kong.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.autoscaling.kong.enabled }}
   replicas: {{ .Values.deployment.kong.replicaCount }}
@@ -14,28 +19,52 @@ spec:
       {{- include "supabase.kong.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      labels:
+        {{- include "supabase.kong.selectorLabels" . | nindent 8 }}
       {{- with .Values.deployment.kong.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      labels:
-        {{- include "supabase.kong.selectorLabels" . | nindent 8 }}
     spec:
+      serviceAccountName: {{ include "supabase.kong.serviceAccountName" . }}
+      {{- if hasKey .Values.deployment.kong "automountServiceAccountToken" }}
+      automountServiceAccountToken: {{ .Values.deployment.kong.automountServiceAccountToken }}
+      {{- end }}
+      restartPolicy: Always
+      {{- if hasKey .Values.deployment.kong "terminationGracePeriodSeconds" }}
+      terminationGracePeriodSeconds: {{ .Values.deployment.kong.terminationGracePeriodSeconds }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.deployment.kong.podSecurityContext | nindent 8 }}
       {{- with .Values.image.kong.pullSecrets}}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "supabase.kong.serviceAccountName" . }}
-      securityContext:
-        {{- toYaml .Values.deployment.kong.podSecurityContext | nindent 8 }}
+      {{- with .Values.deployment.kong.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.kong.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.kong.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.kong.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       containers:
         - name: {{ include "supabase.kong.name" $ }}
-          securityContext:
-            {{- toYaml .Values.deployment.kong.securityContext | nindent 12 }}
           image: "{{ .Values.image.kong.repository }}:{{ .Values.image.kong.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.kong.pullPolicy }}
           command: ["/bin/bash"]
           args: ["/scripts/kong-entrypoint.sh"]
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
           env:
             {{- range $key, $value := .Values.environment.kong }}
             - name: {{ $key }}
@@ -83,18 +112,10 @@ spec:
                   name: {{ include "supabase.secret.dashboard.name" . }}
                   key: {{ include "supabase.secret.dashboard.key.password" . }}
             {{- end }}
-          {{- with .Values.deployment.kong.livenessProbe }}
-          livenessProbe:
+          {{- with .Values.deployment.kong.envFrom }}
+          envFrom:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.deployment.kong.readinessProbe }}
-          readinessProbe:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          ports:
-            - name: http
-              containerPort: 8000
-              protocol: TCP
           {{- with .Values.deployment.kong.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -108,18 +129,24 @@ spec:
             {{- with .Values.deployment.kong.volumeMounts }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
-      {{- with .Values.deployment.kong.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.deployment.kong.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.deployment.kong.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+          {{- with .Values.deployment.kong.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.deployment.kong.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.deployment.kong.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.deployment.kong.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.deployment.kong.securityContext | nindent 12 }}
       volumes:
         - name: config
           configMap:

--- a/charts/supabase/templates/kong/deployment.yaml
+++ b/charts/supabase/templates/kong/deployment.yaml
@@ -27,13 +27,9 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ include "supabase.kong.serviceAccountName" . }}
-      {{- if hasKey .Values.deployment.kong "automountServiceAccountToken" }}
       automountServiceAccountToken: {{ .Values.deployment.kong.automountServiceAccountToken }}
-      {{- end }}
       restartPolicy: Always
-      {{- if hasKey .Values.deployment.kong "terminationGracePeriodSeconds" }}
       terminationGracePeriodSeconds: {{ .Values.deployment.kong.terminationGracePeriodSeconds }}
-      {{- end }}
       securityContext:
         {{- toYaml .Values.deployment.kong.podSecurityContext | nindent 8 }}
       {{- with .Values.image.kong.pullSecrets}}

--- a/charts/supabase/templates/meta/deployment.yaml
+++ b/charts/supabase/templates/meta/deployment.yaml
@@ -27,13 +27,9 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ include "supabase.meta.serviceAccountName" . }}
-      {{- if hasKey .Values.deployment.meta "automountServiceAccountToken" }}
       automountServiceAccountToken: {{ .Values.deployment.meta.automountServiceAccountToken }}
-      {{- end }}
       restartPolicy: Always
-      {{- if hasKey .Values.deployment.meta "terminationGracePeriodSeconds" }}
       terminationGracePeriodSeconds: {{ .Values.deployment.meta.terminationGracePeriodSeconds }}
-      {{- end }}
       securityContext:
         {{- toYaml .Values.deployment.meta.podSecurityContext | nindent 8 }}
       {{- with .Values.image.meta.pullSecrets}}

--- a/charts/supabase/templates/meta/deployment.yaml
+++ b/charts/supabase/templates/meta/deployment.yaml
@@ -3,8 +3,13 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "supabase.meta.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.deployment.meta.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.autoscaling.meta.enabled }}
   replicas: {{ .Values.deployment.meta.replicaCount }}
@@ -14,26 +19,50 @@ spec:
       {{- include "supabase.meta.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      labels:
+        {{- include "supabase.meta.selectorLabels" . | nindent 8 }}
       {{- with .Values.deployment.meta.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      labels:
-        {{- include "supabase.meta.selectorLabels" . | nindent 8 }}
     spec:
+      serviceAccountName: {{ include "supabase.meta.serviceAccountName" . }}
+      {{- if hasKey .Values.deployment.meta "automountServiceAccountToken" }}
+      automountServiceAccountToken: {{ .Values.deployment.meta.automountServiceAccountToken }}
+      {{- end }}
+      restartPolicy: Always
+      {{- if hasKey .Values.deployment.meta "terminationGracePeriodSeconds" }}
+      terminationGracePeriodSeconds: {{ .Values.deployment.meta.terminationGracePeriodSeconds }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.deployment.meta.podSecurityContext | nindent 8 }}
       {{- with .Values.image.meta.pullSecrets}}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "supabase.meta.serviceAccountName" . }}
-      securityContext:
-        {{- toYaml .Values.deployment.meta.podSecurityContext | nindent 8 }}
+      {{- with .Values.deployment.meta.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.meta.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.meta.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.meta.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       containers:
         - name: {{ include "supabase.meta.name" $ }}
-          securityContext:
-            {{- toYaml .Values.deployment.meta.securityContext | nindent 12 }}
           image: "{{ .Values.image.meta.repository }}:{{ .Values.image.meta.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.meta.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
           env:
             {{- range $key, $value := .Values.environment.meta }}
             {{- if and (ne $key "DB_HOST") (ne $key "DB_PORT") }}
@@ -74,20 +103,10 @@ spec:
                 secretKeyRef:
                   name: {{ include "supabase.secret.meta.name" . }}
                   key: {{ include "supabase.secret.meta.key.cryptoKey" . }}
-
-
-          {{- with .Values.deployment.meta.livenessProbe }}
-          livenessProbe:
+          {{- with .Values.deployment.meta.envFrom }}
+          envFrom:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.deployment.meta.readinessProbe }}
-          readinessProbe:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          ports:
-            - name: http
-              containerPort: 8080
-              protocol: TCP
           {{- with .Values.deployment.meta.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -96,20 +115,26 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.deployment.meta.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.deployment.meta.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.deployment.meta.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.deployment.meta.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.deployment.meta.securityContext | nindent 12 }}
       {{- with .Values.deployment.meta.volumes }}
       volumes:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.deployment.meta.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.deployment.meta.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.deployment.meta.tolerations }}
-      tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/charts/supabase/templates/minio/deployment.yaml
+++ b/charts/supabase/templates/minio/deployment.yaml
@@ -27,13 +27,9 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ include "supabase.minio.serviceAccountName" . }}
-      {{- if hasKey .Values.deployment.minio "automountServiceAccountToken" }}
       automountServiceAccountToken: {{ .Values.deployment.minio.automountServiceAccountToken }}
-      {{- end }}
       restartPolicy: Always
-      {{- if hasKey .Values.deployment.minio "terminationGracePeriodSeconds" }}
       terminationGracePeriodSeconds: {{ .Values.deployment.minio.terminationGracePeriodSeconds }}
-      {{- end }}
       securityContext:
         {{- toYaml .Values.deployment.minio.podSecurityContext | nindent 8 }}
       {{- with .Values.image.minio.pullSecrets}}

--- a/charts/supabase/templates/minio/deployment.yaml
+++ b/charts/supabase/templates/minio/deployment.yaml
@@ -3,8 +3,13 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "supabase.minio.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.deployment.minio.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.autoscaling.minio.enabled }}
   replicas: {{ .Values.deployment.minio.replicaCount }}
@@ -14,25 +19,44 @@ spec:
       {{- include "supabase.minio.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      labels:
+        {{- include "supabase.minio.selectorLabels" . | nindent 8 }}
       {{- with .Values.deployment.minio.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      labels:
-        {{- include "supabase.minio.selectorLabels" . | nindent 8 }}
     spec:
+      serviceAccountName: {{ include "supabase.minio.serviceAccountName" . }}
+      {{- if hasKey .Values.deployment.minio "automountServiceAccountToken" }}
+      automountServiceAccountToken: {{ .Values.deployment.minio.automountServiceAccountToken }}
+      {{- end }}
       restartPolicy: Always
+      {{- if hasKey .Values.deployment.minio "terminationGracePeriodSeconds" }}
+      terminationGracePeriodSeconds: {{ .Values.deployment.minio.terminationGracePeriodSeconds }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.deployment.minio.podSecurityContext | nindent 8 }}
       {{- with .Values.image.minio.pullSecrets}}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "supabase.minio.serviceAccountName" . }}
-      securityContext:
-        {{- toYaml .Values.deployment.minio.podSecurityContext | nindent 8 }}
+      {{- with .Values.deployment.minio.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.minio.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.minio.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.minio.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       containers:
         - name: {{ include "supabase.minio.name" $ }}
-          securityContext:
-            {{- toYaml .Values.deployment.minio.securityContext | nindent 12 }}
           image: "{{ .Values.image.minio.repository }}:{{ .Values.image.minio.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.minio.pullPolicy }}
           args:
@@ -40,6 +64,10 @@ spec:
             - --console-address
             - ":9001"
             - /data
+          ports:
+            - name: http
+              containerPort: 9000
+              protocol: TCP
           env:
             - name: MINIO_ROOT_USER
               valueFrom:
@@ -56,18 +84,10 @@ spec:
                   name: {{ include "supabase.secret.minio.name" . }}
                   key: {{ include "supabase.secret.minio.key.password" . }}
                   {{- end }}
-          {{- with .Values.deployment.minio.livenessProbe }}
-          livenessProbe:
+          {{- with .Values.deployment.minio.envFrom }}
+          envFrom:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.deployment.minio.readinessProbe }}
-          readinessProbe:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          ports:
-            - name: http
-              containerPort: 9000
-              protocol: TCP
           {{- with .Values.deployment.minio.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -78,18 +98,24 @@ spec:
           {{- end }}
             - mountPath: /data
               name: minio-data
-      {{- with .Values.deployment.minio.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.deployment.minio.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.deployment.minio.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+          {{- with .Values.deployment.minio.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.deployment.minio.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.deployment.minio.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.deployment.minio.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.deployment.minio.securityContext | nindent 12 }}
       volumes:
         - name: minio-data
           {{- if .Values.persistence.minio.enabled }}

--- a/charts/supabase/templates/realtime/deployment.yaml
+++ b/charts/supabase/templates/realtime/deployment.yaml
@@ -3,8 +3,13 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "supabase.realtime.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.deployment.realtime.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.autoscaling.realtime.enabled }}
   replicas: {{ .Values.deployment.realtime.replicaCount }}
@@ -14,20 +19,42 @@ spec:
       {{- include "supabase.realtime.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      labels:
+        {{- include "supabase.realtime.selectorLabels" . | nindent 8 }}
       {{- with .Values.deployment.realtime.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      labels:
-        {{- include "supabase.realtime.selectorLabels" . | nindent 8 }}
     spec:
+      serviceAccountName: {{ include "supabase.realtime.serviceAccountName" . }}
+      {{- if hasKey .Values.deployment.realtime "automountServiceAccountToken" }}
+      automountServiceAccountToken: {{ .Values.deployment.realtime.automountServiceAccountToken }}
+      {{- end }}
+      restartPolicy: Always
+      {{- if hasKey .Values.deployment.realtime "terminationGracePeriodSeconds" }}
+      terminationGracePeriodSeconds: {{ .Values.deployment.realtime.terminationGracePeriodSeconds }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.deployment.realtime.podSecurityContext | nindent 8 }}
       {{- with .Values.image.realtime.pullSecrets}}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "supabase.realtime.serviceAccountName" . }}
-      securityContext:
-        {{- toYaml .Values.deployment.realtime.podSecurityContext | nindent 8 }}
+      {{- with .Values.deployment.realtime.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.realtime.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.realtime.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.realtime.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       initContainers:
         - name: init-db
           image: "{{ .Values.image.initDb.repository }}:{{ .Values.image.initDb.tag }}"
@@ -45,12 +72,14 @@ spec:
             - echo "Database is ready"
       containers:
         - name: {{ include "supabase.realtime.name" $ }}
-          securityContext:
-            {{- toYaml .Values.deployment.realtime.securityContext | nindent 12 }}
           image: "{{ .Values.image.realtime.repository }}:{{ .Values.image.realtime.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.realtime.pullPolicy }}
           command: ["/bin/sh"]
           args: ["-c", "/app/bin/migrate && /app/bin/realtime eval 'Realtime.Release.seeds(Realtime.Repo)' && /app/bin/server"]
+          ports:
+            - name: http
+              containerPort: 4000
+              protocol: TCP
           env:
             {{- range $key, $value := .Values.environment.realtime }}
             {{- if and (ne $key "DB_HOST") (ne $key "DB_PORT") }}
@@ -99,19 +128,10 @@ spec:
                 secretKeyRef:
                   name: {{ include "supabase.secret.realtime.name" . }}
                   key: {{ include "supabase.secret.realtime.key.secretKeyBase" . }}
-
-          {{- with .Values.deployment.realtime.livenessProbe }}
-          livenessProbe:
+          {{- with .Values.deployment.realtime.envFrom }}
+          envFrom:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.deployment.realtime.readinessProbe }}
-          readinessProbe:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          ports:
-            - name: http
-              containerPort: 4000
-              protocol: TCP
           {{- with .Values.deployment.realtime.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -120,20 +140,26 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.deployment.realtime.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.deployment.realtime.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.deployment.realtime.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.deployment.realtime.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.deployment.realtime.securityContext | nindent 12 }}
       {{- with .Values.deployment.realtime.volumes }}
       volumes:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.deployment.realtime.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.deployment.realtime.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.deployment.realtime.tolerations }}
-      tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/charts/supabase/templates/realtime/deployment.yaml
+++ b/charts/supabase/templates/realtime/deployment.yaml
@@ -27,13 +27,9 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ include "supabase.realtime.serviceAccountName" . }}
-      {{- if hasKey .Values.deployment.realtime "automountServiceAccountToken" }}
       automountServiceAccountToken: {{ .Values.deployment.realtime.automountServiceAccountToken }}
-      {{- end }}
       restartPolicy: Always
-      {{- if hasKey .Values.deployment.realtime "terminationGracePeriodSeconds" }}
       terminationGracePeriodSeconds: {{ .Values.deployment.realtime.terminationGracePeriodSeconds }}
-      {{- end }}
       securityContext:
         {{- toYaml .Values.deployment.realtime.podSecurityContext | nindent 8 }}
       {{- with .Values.image.realtime.pullSecrets}}

--- a/charts/supabase/templates/rest/deployment.yaml
+++ b/charts/supabase/templates/rest/deployment.yaml
@@ -27,13 +27,9 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ include "supabase.rest.serviceAccountName" . }}
-      {{- if hasKey .Values.deployment.rest "automountServiceAccountToken" }}
       automountServiceAccountToken: {{ .Values.deployment.rest.automountServiceAccountToken }}
-      {{- end }}
       restartPolicy: Always
-      {{- if hasKey .Values.deployment.rest "terminationGracePeriodSeconds" }}
       terminationGracePeriodSeconds: {{ .Values.deployment.rest.terminationGracePeriodSeconds }}
-      {{- end }}
       securityContext:
         {{- toYaml .Values.deployment.rest.podSecurityContext | nindent 8 }}
       {{- with .Values.image.rest.pullSecrets}}

--- a/charts/supabase/templates/rest/deployment.yaml
+++ b/charts/supabase/templates/rest/deployment.yaml
@@ -3,8 +3,13 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "supabase.rest.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.deployment.rest.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.autoscaling.rest.enabled }}
   replicas: {{ .Values.deployment.rest.replicaCount }}
@@ -14,20 +19,42 @@ spec:
       {{- include "supabase.rest.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      labels:
+        {{- include "supabase.rest.selectorLabels" . | nindent 8 }}
       {{- with .Values.deployment.rest.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      labels:
-        {{- include "supabase.rest.selectorLabels" . | nindent 8 }}
     spec:
+      serviceAccountName: {{ include "supabase.rest.serviceAccountName" . }}
+      {{- if hasKey .Values.deployment.rest "automountServiceAccountToken" }}
+      automountServiceAccountToken: {{ .Values.deployment.rest.automountServiceAccountToken }}
+      {{- end }}
+      restartPolicy: Always
+      {{- if hasKey .Values.deployment.rest "terminationGracePeriodSeconds" }}
+      terminationGracePeriodSeconds: {{ .Values.deployment.rest.terminationGracePeriodSeconds }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.deployment.rest.podSecurityContext | nindent 8 }}
       {{- with .Values.image.rest.pullSecrets}}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "supabase.rest.serviceAccountName" . }}
-      securityContext:
-        {{- toYaml .Values.deployment.rest.podSecurityContext | nindent 8 }}
+      {{- with .Values.deployment.rest.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.rest.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.rest.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.rest.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       initContainers:
         - name: init-db
           image: "{{ .Values.image.initDb.repository }}:{{ .Values.image.initDb.tag }}"
@@ -45,10 +72,12 @@ spec:
             - echo "Database is ready"
       containers:
         - name: {{ include "supabase.rest.name" $ }}
-          securityContext:
-            {{- toYaml .Values.deployment.rest.securityContext | nindent 12 }}
           image: "{{ .Values.image.rest.repository }}:{{ .Values.image.rest.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.rest.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
           env:
             {{- range $key, $value := .Values.environment.rest }}
             {{- if and (ne $key "DB_HOST") (ne $key "DB_PORT") }}
@@ -94,18 +123,10 @@ spec:
                 secretKeyRef:
                   name: {{ include "supabase.secret.jwt.name" . }}
                   key: {{ include "supabase.secret.jwt.key.secret" . }}
-          {{- with .Values.deployment.rest.livenessProbe }}
-          livenessProbe:
+          {{- with .Values.deployment.rest.envFrom }}
+          envFrom:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.deployment.rest.readinessProbe }}
-          readinessProbe:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          ports:
-            - name: http
-              containerPort: 3000
-              protocol: TCP
           {{- with .Values.deployment.rest.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -114,20 +135,26 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.deployment.rest.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.deployment.rest.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.deployment.rest.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.deployment.rest.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.deployment.rest.securityContext | nindent 12 }}
       {{- with .Values.deployment.rest.volumes }}
       volumes:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.deployment.rest.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.deployment.rest.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.deployment.rest.tolerations }}
-      tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/charts/supabase/templates/storage/deployment.yaml
+++ b/charts/supabase/templates/storage/deployment.yaml
@@ -3,8 +3,13 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "supabase.storage.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.deployment.storage.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.autoscaling.storage.enabled }}
   replicas: {{ .Values.deployment.storage.replicaCount }}
@@ -14,21 +19,42 @@ spec:
       {{- include "supabase.storage.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      labels:
+        {{- include "supabase.storage.selectorLabels" . | nindent 8 }}
       {{- with .Values.deployment.storage.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      labels:
-        {{- include "supabase.storage.selectorLabels" . | nindent 8 }}
     spec:
+      serviceAccountName: {{ include "supabase.storage.serviceAccountName" . }}
+      {{- if hasKey .Values.deployment.storage "automountServiceAccountToken" }}
+      automountServiceAccountToken: {{ .Values.deployment.storage.automountServiceAccountToken }}
+      {{- end }}
       restartPolicy: Always
+      {{- if hasKey .Values.deployment.storage "terminationGracePeriodSeconds" }}
+      terminationGracePeriodSeconds: {{ .Values.deployment.storage.terminationGracePeriodSeconds }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.deployment.storage.podSecurityContext | nindent 8 }}
       {{- with .Values.image.storage.pullSecrets}}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "supabase.storage.serviceAccountName" . }}
-      securityContext:
-        {{- toYaml .Values.deployment.storage.podSecurityContext | nindent 8 }}
+      {{- with .Values.deployment.storage.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.storage.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.storage.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.storage.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       initContainers:
         - name: init-db
           image: "{{ .Values.image.initDb.repository }}:{{ .Values.image.initDb.tag }}"
@@ -81,10 +107,12 @@ spec:
         {{- end }}
       containers:
         - name: {{ include "supabase.storage.name" $ }}
-          securityContext:
-            {{- toYaml .Values.deployment.storage.securityContext | nindent 12 }}
           image: "{{ .Values.image.storage.repository }}:{{ .Values.image.storage.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.storage.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 5000
+              protocol: TCP
           env:
             {{- range $key, $value := .Values.environment.storage }}
             {{- if and (ne $key "AWS_ACCESS_KEY_ID") (ne $key "AWS_SECRET_ACCESS_KEY") (ne $key "STORAGE_BACKEND") (ne $key "DB_HOST") (ne $key "DB_PORT") }}
@@ -204,18 +232,10 @@ spec:
             - name: GLOBAL_S3_FORCE_PATH_STYLE
               value: "true"
             {{- end }}
-          {{- with .Values.deployment.storage.livenessProbe }}
-          livenessProbe:
+          {{- with .Values.deployment.storage.envFrom }}
+          envFrom:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.deployment.storage.readinessProbe }}
-          readinessProbe:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          ports:
-            - name: http
-              containerPort: 5000
-              protocol: TCP
           {{- with .Values.deployment.storage.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -226,18 +246,24 @@ spec:
           {{- end }}
             - mountPath: /var/lib/storage
               name: storage-data
-      {{- with .Values.deployment.storage.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.deployment.storage.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.deployment.storage.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+          {{- with .Values.deployment.storage.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.deployment.storage.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.deployment.storage.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.deployment.storage.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.deployment.storage.securityContext | nindent 12 }}
       volumes:
         - name: storage-data
           {{- if .Values.persistence.storage.enabled }}

--- a/charts/supabase/templates/storage/deployment.yaml
+++ b/charts/supabase/templates/storage/deployment.yaml
@@ -27,13 +27,9 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ include "supabase.storage.serviceAccountName" . }}
-      {{- if hasKey .Values.deployment.storage "automountServiceAccountToken" }}
       automountServiceAccountToken: {{ .Values.deployment.storage.automountServiceAccountToken }}
-      {{- end }}
       restartPolicy: Always
-      {{- if hasKey .Values.deployment.storage "terminationGracePeriodSeconds" }}
       terminationGracePeriodSeconds: {{ .Values.deployment.storage.terminationGracePeriodSeconds }}
-      {{- end }}
       securityContext:
         {{- toYaml .Values.deployment.storage.podSecurityContext | nindent 8 }}
       {{- with .Values.image.storage.pullSecrets}}

--- a/charts/supabase/templates/studio/deployment.yaml
+++ b/charts/supabase/templates/studio/deployment.yaml
@@ -3,8 +3,13 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "supabase.studio.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.deployment.studio.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.autoscaling.studio.enabled }}
   replicas: {{ .Values.deployment.studio.replicaCount }}
@@ -14,26 +19,50 @@ spec:
       {{- include "supabase.studio.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      labels:
+        {{- include "supabase.studio.selectorLabels" . | nindent 8 }}
       {{- with .Values.deployment.studio.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      labels:
-        {{- include "supabase.studio.selectorLabels" . | nindent 8 }}
     spec:
+      serviceAccountName: {{ include "supabase.studio.serviceAccountName" . }}
+      {{- if hasKey .Values.deployment.studio "automountServiceAccountToken" }}
+      automountServiceAccountToken: {{ .Values.deployment.studio.automountServiceAccountToken }}
+      {{- end }}
+      restartPolicy: Always
+      {{- if hasKey .Values.deployment.studio "terminationGracePeriodSeconds" }}
+      terminationGracePeriodSeconds: {{ .Values.deployment.studio.terminationGracePeriodSeconds }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.deployment.studio.podSecurityContext | nindent 8 }}
       {{- with .Values.image.studio.pullSecrets}}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "supabase.studio.serviceAccountName" . }}
-      securityContext:
-        {{- toYaml .Values.deployment.studio.podSecurityContext | nindent 8 }}
+      {{- with .Values.deployment.studio.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.studio.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.studio.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.studio.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       containers:
         - name: {{ include "supabase.studio.name" $ }}
-          securityContext:
-            {{- toYaml .Values.deployment.studio.securityContext | nindent 12 }}
           image: "{{ .Values.image.studio.repository }}:{{ .Values.image.studio.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.studio.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
           env:
             {{- range $key, $value := .Values.environment.studio }}
             - name: {{ $key }}
@@ -122,18 +151,10 @@ spec:
             - name: SNIPPETS_MANAGEMENT_FOLDER
               value: /app/snippets
             {{- end }}
-          {{- with .Values.deployment.studio.livenessProbe }}
-          livenessProbe:
+          {{- with .Values.deployment.studio.envFrom }}
+          envFrom:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.deployment.studio.readinessProbe }}
-          readinessProbe:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          ports:
-            - name: http
-              containerPort: 3000
-              protocol: TCP
           {{- with .Values.deployment.studio.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -152,6 +173,24 @@ spec:
               mountPath: /app/snippets
             {{- end }}
           {{- end }}
+          {{- with .Values.deployment.studio.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.deployment.studio.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.deployment.studio.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.deployment.studio.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.deployment.studio.securityContext | nindent 12 }}
       {{- if or .Values.deployment.studio.volumes .Values.persistence.functions.enabled .Values.persistence.snippets.enabled }}
       volumes:
         {{- with .Values.deployment.studio.volumes }}
@@ -167,17 +206,5 @@ spec:
           persistentVolumeClaim:
             claimName: {{ include "supabase.pvc.name" (dict "root" $ "name" "snippets") }}
         {{- end }}
-      {{- end }}
-      {{- with .Values.deployment.studio.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.deployment.studio.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.deployment.studio.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/charts/supabase/templates/studio/deployment.yaml
+++ b/charts/supabase/templates/studio/deployment.yaml
@@ -27,13 +27,9 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ include "supabase.studio.serviceAccountName" . }}
-      {{- if hasKey .Values.deployment.studio "automountServiceAccountToken" }}
       automountServiceAccountToken: {{ .Values.deployment.studio.automountServiceAccountToken }}
-      {{- end }}
       restartPolicy: Always
-      {{- if hasKey .Values.deployment.studio "terminationGracePeriodSeconds" }}
       terminationGracePeriodSeconds: {{ .Values.deployment.studio.terminationGracePeriodSeconds }}
-      {{- end }}
       securityContext:
         {{- toYaml .Values.deployment.studio.podSecurityContext | nindent 8 }}
       {{- with .Values.image.studio.pullSecrets}}

--- a/charts/supabase/templates/vector/deployment.yaml
+++ b/charts/supabase/templates/vector/deployment.yaml
@@ -29,13 +29,9 @@ spec:
         checksum/config: {{ tpl (.Files.Get "files/vector/vector.yml") . | sha256sum }}
     spec:
       serviceAccountName: {{ include "supabase.vector.serviceAccountName" . }}
-      {{- if hasKey .Values.deployment.vector "automountServiceAccountToken" }}
       automountServiceAccountToken: {{ .Values.deployment.vector.automountServiceAccountToken }}
-      {{- end }}
       restartPolicy: Always
-      {{- if hasKey .Values.deployment.vector "terminationGracePeriodSeconds" }}
       terminationGracePeriodSeconds: {{ .Values.deployment.vector.terminationGracePeriodSeconds }}
-      {{- end }}
       securityContext:
         {{- toYaml .Values.deployment.vector.podSecurityContext | nindent 8 }}
       {{- with .Values.image.vector.pullSecrets}}

--- a/charts/supabase/templates/vector/deployment.yaml
+++ b/charts/supabase/templates/vector/deployment.yaml
@@ -3,9 +3,14 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "supabase.vector.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
     vector.dev/exclude: "true"
+  {{- with .Values.deployment.vector.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.autoscaling.vector.enabled }}
   replicas: {{ .Values.deployment.vector.replicaCount }}
@@ -15,30 +20,53 @@ spec:
       {{- include "supabase.vector.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      annotations:
-      {{- with .Values.deployment.vector.podAnnotations }}
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-        checksum/config: {{ tpl (.Files.Get "files/vector/vector.yml") . | sha256sum }}
       labels:
         {{- include "supabase.vector.selectorLabels" . | nindent 8 }}
+      annotations:
+        {{- with .Values.deployment.vector.podAnnotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+        checksum/config: {{ tpl (.Files.Get "files/vector/vector.yml") . | sha256sum }}
     spec:
+      serviceAccountName: {{ include "supabase.vector.serviceAccountName" . }}
+      {{- if hasKey .Values.deployment.vector "automountServiceAccountToken" }}
+      automountServiceAccountToken: {{ .Values.deployment.vector.automountServiceAccountToken }}
+      {{- end }}
+      restartPolicy: Always
+      {{- if hasKey .Values.deployment.vector "terminationGracePeriodSeconds" }}
+      terminationGracePeriodSeconds: {{ .Values.deployment.vector.terminationGracePeriodSeconds }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.deployment.vector.podSecurityContext | nindent 8 }}
       {{- with .Values.image.vector.pullSecrets}}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "supabase.vector.serviceAccountName" . }}
-      securityContext:
-        {{- toYaml .Values.deployment.vector.podSecurityContext | nindent 8 }}
+      {{- with .Values.deployment.vector.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.vector.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.vector.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.vector.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       containers:
-        - args:
-            - --config
-            - /etc/vector/vector.yml
-          name: {{ include "supabase.vector.name" $ }}
-          securityContext:
-            {{- toYaml .Values.deployment.vector.securityContext | nindent 12 }}
+        - name: {{ include "supabase.vector.name" $ }}
           image: "{{ .Values.image.vector.repository }}:{{ .Values.image.vector.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.vector.pullPolicy }}
+          args:
+            - --config
+            - /etc/vector/vector.yml
+          ports:
+            - containerPort: {{ .Values.service.vector.port }}
+              protocol: TCP
           env:
             {{- range $key, $value := .Values.environment.vector }}
             - name: {{ $key }}
@@ -55,17 +83,14 @@ spec:
                   name: {{ include "supabase.secret.analytics.name" . }}
                   key: {{ include "supabase.secret.analytics.key.publicAccessToken" . }}
             {{- end }}
-          {{- with .Values.deployment.vector.livenessProbe }}
-          livenessProbe:
+          {{- with .Values.deployment.vector.envFrom }}
+          envFrom:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.deployment.vector.readinessProbe }}
-          readinessProbe:
+          {{- with .Values.deployment.vector.resources }}
+          resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          ports:
-            - containerPort: {{ .Values.service.vector.port }}
-              protocol: TCP
           volumeMounts:
             {{- with .Values.deployment.vector.volumeMounts }}
               {{- toYaml . | nindent 12 }}
@@ -79,10 +104,24 @@ spec:
             - name: varlibdockercontainers
               mountPath: /var/lib/docker/containers
               readOnly: true
-          {{- with .Values.deployment.vector.resources }}
-          resources:
+          {{- with .Values.deployment.vector.livenessProbe }}
+          livenessProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.deployment.vector.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.deployment.vector.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.deployment.vector.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.deployment.vector.securityContext | nindent 12 }}
       volumes:
         {{- with .Values.deployment.vector.volumes }}
           {{- toYaml . | nindent 8 }}
@@ -97,16 +136,4 @@ spec:
         - name: varlibdockercontainers
           hostPath:
             path: /var/lib/docker/containers
-      {{- with .Values.deployment.vector.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.deployment.vector.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.deployment.vector.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
 {{- end }}

--- a/charts/supabase/values.yaml
+++ b/charts/supabase/values.yaml
@@ -224,51 +224,72 @@ deployment:
     replicaCount: 1
     nameOverride: ""
     fullnameOverride: ""
-    livenessProbe: {}
-    readinessProbe: {}
+    annotations: {}
     podAnnotations: {}
     podSecurityContext:
     securityContext: {}
+    automountServiceAccountToken: true
+    terminationGracePeriodSeconds: 30
     nodeSelector: {}
-    tolerations: []
     affinity: {}
+    tolerations: []
+    priorityClassName: ""
+    envFrom: []
+    livenessProbe: {}
+    readinessProbe: {}
+    startupProbe: {}
+    lifecycle: {}
+    resources: {}
     volumeMounts: {}
     volumes: {}
-    resources: {}
 
   auth:
     enabled: true
     replicaCount: 1
     nameOverride: ""
     fullnameOverride: ""
-    livenessProbe: {}
-    readinessProbe: {}
+    annotations: {}
     podAnnotations: {}
     podSecurityContext:
     securityContext: {}
+    automountServiceAccountToken: true
+    terminationGracePeriodSeconds: 30
     nodeSelector: {}
-    tolerations: []
     affinity: {}
+    tolerations: []
+    priorityClassName: ""
+    envFrom: []
+    livenessProbe: {}
+    readinessProbe: {}
+    startupProbe: {}
+    lifecycle: {}
+    resources: {}
     volumeMounts: {}
     volumes: {}
-    resources: {}
 
   db:
     enabled: true
     replicaCount: 1
     nameOverride: ""
     fullnameOverride: ""
-    livenessProbe: {}
-    readinessProbe: {}
+    annotations: {}
     podAnnotations: {}
     podSecurityContext:
     securityContext: {}
+    automountServiceAccountToken: true
+    terminationGracePeriodSeconds: 30
     nodeSelector: {}
-    tolerations: []
     affinity: {}
+    tolerations: []
+    priorityClassName: ""
+    envFrom: []
+    livenessProbe: {}
+    readinessProbe: {}
+    startupProbe: {}
+    lifecycle: {}
+    resources: {}
     volumeMounts: {}
     volumes: {}
-    resources: {}
     extraInitContainers: []
 
   functions:
@@ -276,136 +297,192 @@ deployment:
     replicaCount: 1
     nameOverride: ""
     fullnameOverride: ""
-    livenessProbe: {}
-    readinessProbe: {}
+    annotations: {}
     podAnnotations: {}
     podSecurityContext:
     securityContext: {}
+    automountServiceAccountToken: true
+    terminationGracePeriodSeconds: 30
     nodeSelector: {}
-    tolerations: []
     affinity: {}
+    tolerations: []
+    priorityClassName: ""
+    envFrom: []
+    livenessProbe: {}
+    readinessProbe: {}
+    startupProbe: {}
+    lifecycle: {}
+    resources: {}
     volumeMounts: {}
     volumes: {}
-    resources: {}
 
   imgproxy:
     enabled: true
     replicaCount: 1
     nameOverride: ""
     fullnameOverride: ""
-    livenessProbe: {}
-    readinessProbe: {}
+    annotations: {}
     podAnnotations: {}
     podSecurityContext:
     securityContext: {}
+    automountServiceAccountToken: true
+    terminationGracePeriodSeconds: 30
     nodeSelector: {}
-    tolerations: []
     affinity: {}
+    tolerations: []
+    priorityClassName: ""
+    envFrom: []
+    livenessProbe: {}
+    readinessProbe: {}
+    startupProbe: {}
+    lifecycle: {}
+    resources: {}
     volumeMounts: {}
     volumes: {}
-    resources: {}
 
   kong:
     enabled: true
     replicaCount: 1
     nameOverride: ""
     fullnameOverride: ""
-    livenessProbe: {}
-    readinessProbe: {}
+    annotations: {}
     podAnnotations: {}
     podSecurityContext:
     securityContext: {}
+    automountServiceAccountToken: true
+    terminationGracePeriodSeconds: 30
     nodeSelector: {}
-    tolerations: []
     affinity: {}
+    tolerations: []
+    priorityClassName: ""
+    envFrom: []
+    livenessProbe: {}
+    readinessProbe: {}
+    startupProbe: {}
+    lifecycle: {}
+    resources: {}
     volumeMounts: {}
     volumes: {}
-    resources: {}
 
   meta:
     enabled: true
     replicaCount: 1
     nameOverride: ""
     fullnameOverride: ""
-    livenessProbe: {}
-    readinessProbe: {}
+    annotations: {}
     podAnnotations: {}
     podSecurityContext:
     securityContext: {}
+    automountServiceAccountToken: true
+    terminationGracePeriodSeconds: 30
     nodeSelector: {}
-    tolerations: []
     affinity: {}
+    tolerations: []
+    priorityClassName: ""
+    envFrom: []
+    livenessProbe: {}
+    readinessProbe: {}
+    startupProbe: {}
+    lifecycle: {}
+    resources: {}
     volumeMounts: {}
     volumes: {}
-    resources: {}
 
   minio:
     enabled: false
     replicaCount: 1
     nameOverride: ""
     fullnameOverride: ""
-    livenessProbe: {}
-    readinessProbe: {}
+    annotations: {}
     podAnnotations: {}
     podSecurityContext:
     securityContext: {}
+    automountServiceAccountToken: true
+    terminationGracePeriodSeconds: 30
     nodeSelector: {}
-    tolerations: []
     affinity: {}
+    tolerations: []
+    priorityClassName: ""
+    envFrom: []
+    livenessProbe: {}
+    readinessProbe: {}
+    startupProbe: {}
+    lifecycle: {}
+    resources: {}
     volumeMounts: {}
     volumes: {}
-    resources: {}
 
   realtime:
     enabled: true
     replicaCount: 1
     nameOverride: ""
     fullnameOverride: ""
-    livenessProbe: {}
-    readinessProbe: {}
+    annotations: {}
     podAnnotations: {}
     podSecurityContext:
     securityContext: {}
+    automountServiceAccountToken: true
+    terminationGracePeriodSeconds: 30
     nodeSelector: {}
-    tolerations: []
     affinity: {}
+    tolerations: []
+    priorityClassName: ""
+    envFrom: []
+    livenessProbe: {}
+    readinessProbe: {}
+    startupProbe: {}
+    lifecycle: {}
+    resources: {}
     volumeMounts: {}
     volumes: {}
-    resources: {}
 
   rest:
     enabled: true
     replicaCount: 1
     nameOverride: ""
     fullnameOverride: ""
-    livenessProbe: {}
-    readinessProbe: {}
+    annotations: {}
     podAnnotations: {}
     podSecurityContext:
     securityContext: {}
+    automountServiceAccountToken: true
+    terminationGracePeriodSeconds: 30
     nodeSelector: {}
-    tolerations: []
     affinity: {}
+    tolerations: []
+    priorityClassName: ""
+    envFrom: []
+    livenessProbe: {}
+    readinessProbe: {}
+    startupProbe: {}
+    lifecycle: {}
+    resources: {}
     volumeMounts: {}
     volumes: {}
-    resources: {}
 
   storage:
     enabled: true
     replicaCount: 1
     nameOverride: ""
     fullnameOverride: ""
-    livenessProbe: {}
-    readinessProbe: {}
+    annotations: {}
     podAnnotations: {}
     podSecurityContext:
     securityContext: {}
+    automountServiceAccountToken: true
+    terminationGracePeriodSeconds: 30
     nodeSelector: {}
-    tolerations: []
     affinity: {}
+    tolerations: []
+    priorityClassName: ""
+    envFrom: []
+    livenessProbe: {}
+    readinessProbe: {}
+    startupProbe: {}
+    lifecycle: {}
+    resources: {}
     volumeMounts: {}
     volumes: {}
-    resources: {}
     extraInitContainers: []
 
   studio:
@@ -413,34 +490,48 @@ deployment:
     replicaCount: 1
     nameOverride: ""
     fullnameOverride: ""
-    livenessProbe: {}
-    readinessProbe: {}
+    annotations: {}
     podAnnotations: {}
     podSecurityContext:
     securityContext: {}
+    automountServiceAccountToken: true
+    terminationGracePeriodSeconds: 30
     nodeSelector: {}
-    tolerations: []
     affinity: {}
+    tolerations: []
+    priorityClassName: ""
+    envFrom: []
+    livenessProbe: {}
+    readinessProbe: {}
+    startupProbe: {}
+    lifecycle: {}
+    resources: {}
     volumeMounts: {}
     volumes: {}
-    resources: {}
 
   vector:
     enabled: true
     replicaCount: 1
     nameOverride: ""
     fullnameOverride: ""
-    livenessProbe: {}
-    readinessProbe: {}
+    annotations: {}
     podAnnotations: {}
     podSecurityContext:
     securityContext: {}
+    automountServiceAccountToken: true
+    terminationGracePeriodSeconds: 30
     nodeSelector: {}
-    tolerations: []
     affinity: {}
+    tolerations: []
+    priorityClassName: ""
+    envFrom: []
+    livenessProbe: {}
+    readinessProbe: {}
+    startupProbe: {}
+    lifecycle: {}
+    resources: {}
     volumeMounts: {}
     volumes: {}
-    resources: {}
 
 image:
   analytics:


### PR DESCRIPTION
## What kind of change does this PR introduce?
Chore / maintenance update.
## What is the current behavior?
The Helm chart configuration and workload templates had inconsistent structure and ordering across services, which made maintenance and reviews harder.
## What is the new behavior?
This PR standardizes the structure and ordering of Deployment/StatefulSet templates and aligns `values.yaml` defaults across components for consistency.
## Additional context
This is mainly a consistency/refactor-style change focused on chart maintainability rather than new features.