### PR TITLE
fix(db): Fix indentation for extra init containers

### DIFF
--- a/charts/supabase/templates/db/statefulset.yaml
+++ b/charts/supabase/templates/db/statefulset.yaml
@@ -81,7 +81,7 @@ spec:
             - mountPath: /initdb.d
               name: initdb-scripts-data
       {{- if .Values.deployment.db.extraInitContainers }}
-          {{- toYaml .Values.deployment.db.extraInitContainers | nindent 8 }}
+          {{- toYaml .Values.deployment.db.extraInitContainers | nindent 10 }}
       {{- end }}
       containers:
         - name: {{ include "supabase.db.name" $ }}


### PR DESCRIPTION
Increase indentation for extra init containers in statefulset.yaml.

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

https://github.com/supabase-community/supabase-kubernetes/issues/185

## What is the new behavior?

Template renders correctly when init container resources are set
