### PR TITLE
fix(chart): render autoscaling HPAs

### DIFF
--- a/charts/supabase/README.md
+++ b/charts/supabase/README.md
@@ -169,6 +169,25 @@ secret:
       gcloudJson: gcloud.json
 ```
 
+### Autoscaling
+
+Autoscaling is disabled by default. To enable it for a component, set `autoscaling.<component>.enabled=true` and configure CPU and/or memory requests for that component. Kubernetes HPA utilization metrics require metrics-server and container `resources.requests`.
+
+```yaml
+deployment:
+  auth:
+    resources:
+      requests:
+        cpu: 100m
+
+autoscaling:
+  auth:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 5
+    targetCPUUtilizationPercentage: 80
+```
+
 ### S3 secret
 
 Supabase storage supports the use of S3 object-storage. To enable S3 for Supabase storage:

--- a/charts/supabase/templates/autoscaling.yaml
+++ b/charts/supabase/templates/autoscaling.yaml
@@ -1,0 +1,51 @@
+{{- $components := list
+  (dict "name" "analytics" "kind" "Deployment" "fullname" "supabase.analytics.fullname" "deployment" .Values.deployment.analytics "autoscaling" .Values.autoscaling.analytics)
+  (dict "name" "auth" "kind" "Deployment" "fullname" "supabase.auth.fullname" "deployment" .Values.deployment.auth "autoscaling" .Values.autoscaling.auth)
+  (dict "name" "db" "kind" "StatefulSet" "fullname" "supabase.db.fullname" "deployment" .Values.deployment.db "autoscaling" .Values.autoscaling.db)
+  (dict "name" "functions" "kind" "Deployment" "fullname" "supabase.functions.fullname" "deployment" .Values.deployment.functions "autoscaling" .Values.autoscaling.functions)
+  (dict "name" "imgproxy" "kind" "Deployment" "fullname" "supabase.imgproxy.fullname" "deployment" .Values.deployment.imgproxy "autoscaling" .Values.autoscaling.imgproxy)
+  (dict "name" "kong" "kind" "Deployment" "fullname" "supabase.kong.fullname" "deployment" .Values.deployment.kong "autoscaling" .Values.autoscaling.kong)
+  (dict "name" "meta" "kind" "Deployment" "fullname" "supabase.meta.fullname" "deployment" .Values.deployment.meta "autoscaling" .Values.autoscaling.meta)
+  (dict "name" "minio" "kind" "Deployment" "fullname" "supabase.minio.fullname" "deployment" .Values.deployment.minio "autoscaling" .Values.autoscaling.minio)
+  (dict "name" "realtime" "kind" "Deployment" "fullname" "supabase.realtime.fullname" "deployment" .Values.deployment.realtime "autoscaling" .Values.autoscaling.realtime)
+  (dict "name" "rest" "kind" "Deployment" "fullname" "supabase.rest.fullname" "deployment" .Values.deployment.rest "autoscaling" .Values.autoscaling.rest)
+  (dict "name" "storage" "kind" "Deployment" "fullname" "supabase.storage.fullname" "deployment" .Values.deployment.storage "autoscaling" .Values.autoscaling.storage)
+  (dict "name" "studio" "kind" "Deployment" "fullname" "supabase.studio.fullname" "deployment" .Values.deployment.studio "autoscaling" .Values.autoscaling.studio)
+  (dict "name" "vector" "kind" "Deployment" "fullname" "supabase.vector.fullname" "deployment" .Values.deployment.vector "autoscaling" .Values.autoscaling.vector)
+}}
+{{- range $component := $components }}
+{{- if and $component.deployment.enabled $component.autoscaling.enabled }}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include $component.fullname $ }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "supabase.labels" $ | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: {{ $component.kind }}
+    name: {{ include $component.fullname $ }}
+  minReplicas: {{ $component.autoscaling.minReplicas }}
+  maxReplicas: {{ $component.autoscaling.maxReplicas }}
+  metrics:
+    {{- with $component.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+    {{- end }}
+    {{- with $component.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/supabase/values.yaml
+++ b/charts/supabase/values.yaml
@@ -959,91 +959,91 @@ service:
 
 autoscaling:
   analytics:
-    enabled: true
+    enabled: false
     minReplicas: 1
     maxReplicas: 100
     targetCPUUtilizationPercentage: 80
     # targetMemoryUtilizationPercentage: 80
 
   auth:
-    enabled: true
+    enabled: false
     minReplicas: 1
     maxReplicas: 100
     targetCPUUtilizationPercentage: 80
     # targetMemoryUtilizationPercentage: 80
 
   db:
-    enabled: true
+    enabled: false
     minReplicas: 1
     maxReplicas: 100
     targetCPUUtilizationPercentage: 80
     # targetMemoryUtilizationPercentage: 80
 
   functions:
-    enabled: true
+    enabled: false
     minReplicas: 1
     maxReplicas: 100
     targetCPUUtilizationPercentage: 80
     # targetMemoryUtilizationPercentage: 80
 
   imgproxy:
-    enabled: true
+    enabled: false
     minReplicas: 1
     maxReplicas: 100
     targetCPUUtilizationPercentage: 80
     # targetMemoryUtilizationPercentage: 80
 
   kong:
-    enabled: true
+    enabled: false
     minReplicas: 1
     maxReplicas: 100
     targetCPUUtilizationPercentage: 80
     # targetMemoryUtilizationPercentage: 80
 
   meta:
-    enabled: true
+    enabled: false
     minReplicas: 1
     maxReplicas: 100
     targetCPUUtilizationPercentage: 80
     # targetMemoryUtilizationPercentage: 80
 
   minio:
-    enabled: true
+    enabled: false
     minReplicas: 1
     maxReplicas: 100
     targetCPUUtilizationPercentage: 80
     # targetMemoryUtilizationPercentage: 80
 
   realtime:
-    enabled: true
+    enabled: false
     minReplicas: 1
     maxReplicas: 100
     targetCPUUtilizationPercentage: 80
     # targetMemoryUtilizationPercentage: 80
 
   rest:
-    enabled: true
+    enabled: false
     minReplicas: 1
     maxReplicas: 100
     targetCPUUtilizationPercentage: 80
     # targetMemoryUtilizationPercentage: 80
 
   storage:
-    enabled: true
+    enabled: false
     minReplicas: 1
     maxReplicas: 100
     targetCPUUtilizationPercentage: 80
     # targetMemoryUtilizationPercentage: 80
 
   studio:
-    enabled: true
+    enabled: false
     minReplicas: 1
     maxReplicas: 100
     targetCPUUtilizationPercentage: 80
     # targetMemoryUtilizationPercentage: 80
 
   vector:
-    enabled: true
+    enabled: false
     minReplicas: 1
     maxReplicas: 100
     targetCPUUtilizationPercentage: 80


### PR DESCRIPTION
## Summary

Fixes #188.

This PR makes the chart's autoscaling values functional by rendering autoscaling/v2 HorizontalPodAutoscaler resources for the Supabase components that already expose autoscaling settings.

## Changes

- Add HPA rendering for analytics, auth, db, functions, imgproxy, kong, meta, minio, realtime, rest, storage, studio, and vector.
- Target the db StatefulSet and component Deployments for the other services.
- Keep autoscaling disabled by default because CPU and memory utilization HPAs require container resource requests.
- Document that metrics-server and resources.requests are required for CPU/memory utilization metrics.

## Verification

- helm lint charts/supabase
- helm template default render: no HPA resources and fixed replicas remain
- auth autoscaling render: one HPA targeting Deployment/test-supabase-auth and auth Deployment omits fixed replicas
- auth CPU + memory render: both Resource metrics are present
- disabled auth deployment with auth autoscaling enabled: no orphan HPA is rendered
- db autoscaling render: HPA targets StatefulSet/test-supabase-db