### PR TITLE
chore(chart): pin KONG_NGINX_WORKER_PROCESSES and document memory behavior

### DIFF
--- a/charts/supabase/values.yaml
+++ b/charts/supabase/values.yaml
@@ -713,6 +713,9 @@ environment:
     KONG_NGINX_PROXY_PROXY_BUFFERS: 64 160k
     KONG_LOG_LEVEL: warn
 
+    # Please see: https://github.com/supabase-community/supabase-kubernetes/issues/187
+    KONG_NGINX_WORKER_PROCESSES: "2"
+
   meta:
     DB_USER: supabase_admin
     DB_DRIVER: postgres


### PR DESCRIPTION
 ## What kind of change does this PR introduce?

Docs update / chore

## What is the current behavior?

Closes #187 — Kong RSS scales linearly with host core count on nodes without CPU limits (e.g., OpenShift cgroup v2 reports full host `nproc`, causing OpenResty to spawn one worker per core).

## What is the new behavior?

Pins `KONG_NGINX_WORKER_PROCESSES: "2"` in `values.yaml` with a comment explaining the behavior. Keeps Kong memory usage stable (~200–400 Mi) regardless of underlying host cores.
