### PR TITLE
feat(studio): allow overriding POSTGRES_HOST and POSTGRES_DB via environment.studio

### DIFF
--- a/charts/supabase/templates/studio/deployment.yaml
+++ b/charts/supabase/templates/studio/deployment.yaml
@@ -73,11 +73,12 @@ spec:
               value: http://{{ include "supabase.meta.fullname" . }}:{{ .Values.service.meta.port }}
             {{- end }}
 
-            {{- if .Values.deployment.db.enabled }}
+            {{- if and .Values.deployment.db.enabled (not (hasKey (default (dict) .Values.environment.studio) "POSTGRES_HOST")) }}
             - name: POSTGRES_HOST
               value: {{ include "supabase.db.fullname" . }}
             {{- end }}
 
+            {{- if not (hasKey (default (dict) .Values.environment.studio) "POSTGRES_DB") }}
             - name: POSTGRES_DB
               {{- if and .Values.secret.db.secretRef (not (hasKey (default (dict) .Values.secret.db.secretRefKey) "database")) }}
               value: {{ .Values.secret.db.database | default "postgres" | quote }}
@@ -87,6 +88,7 @@ spec:
                   name: {{ include "supabase.secret.db.name" . }}
                   key: {{ include "supabase.secret.db.key.database" . }}
               {{- end }}
+            {{- end }}
 
             - name: POSTGRES_PASSWORD
               valueFrom:


### PR DESCRIPTION
## Summary

Skip the chart's default `POSTGRES_HOST` and `POSTGRES_DB` env emission when the user has already provided that key under `environment.studio`.

## Motivation

The chart's `env:` block for the Studio deployment emits user-provided values from `environment.studio` first via a `range` loop, then emits chart defaults. K8s API accepts duplicate env names without dedup, and Linux `getenv()` behavior on duplicate environment entries is implementation-defined — so users currently cannot reliably override `POSTGRES_HOST` / `POSTGRES_DB` via the chart's existing values surface.

This matters for **external databases that require SSL**. Supabase Studio's self-hosted code in [`apps/studio/lib/api/self-hosted/util.ts`](https://github.com/supabase/supabase/blob/master/apps/studio/lib/api/self-hosted/util.ts) builds its connection string as:

```js
return `postgresql://${user}:${pass}@${host}:${port}/${db}`
```

…with no SSL parameter and no env var to inject one. The only way to add `sslmode=require` is to append it to the database name. With this PR, that becomes a one-line values override:

```yaml
environment:
  studio:
    POSTGRES_DB: "postgres?sslmode=require"
```

…instead of forking the chart or relying on undefined-behavior of duplicate env vars.

## Behavior

- **Default users:** No change. The chart still emits `POSTGRES_HOST` (when `deployment.db.enabled: true`) and `POSTGRES_DB` from `secret.db.database` / `secret.db.secretRef` exactly as before.
- **Override users:** If `environment.studio.POSTGRES_HOST` or `environment.studio.POSTGRES_DB` is set, the chart skips its default emission for that key. Only the user-provided value appears in the rendered Deployment — no duplicates.

## Test plan

- [x] `helm template` with no override → `POSTGRES_DB` from secret/literal, unchanged behavior
- [x] `helm template` with `environment.studio.POSTGRES_DB: "supabase?sslmode=require"` → exactly one `POSTGRES_DB` env var with the override value, chart default skipped
- [x] Verified against `supabase-0.5.6` baseline in a real ArgoCD + external RDS deployment unblocking Studio's Table Editor against a `rds.force_ssl=1` Postgres instance

## Diff

```diff
-            {{- if .Values.deployment.db.enabled }}
+            {{- if and .Values.deployment.db.enabled (not (hasKey (default (dict) .Values.environment.studio) "POSTGRES_HOST")) }}
             - name: POSTGRES_HOST
               value: {{ include "supabase.db.fullname" . }}
             {{- end }}

+            {{- if not (hasKey (default (dict) .Values.environment.studio) "POSTGRES_DB") }}
             - name: POSTGRES_DB
               {{- if and .Values.secret.db.secretRef (not (hasKey (default (dict) .Values.secret.db.secretRefKey) "database")) }}
               value: {{ .Values.secret.db.database | default "postgres" | quote }}
               {{- else }}
               valueFrom:
                 secretKeyRef:
                   name: {{ include "supabase.secret.db.name" . }}
                   key: {{ include "supabase.secret.db.key.database" . }}
               {{- end }}
+            {{- end }}
```