### PR TITLE
feat(studio): expose deployment.studio.strategy

### DIFF
--- a/charts/supabase/templates/studio/deployment.yaml
+++ b/charts/supabase/templates/studio/deployment.yaml
@@ -14,6 +14,10 @@ spec:
   {{- if not .Values.autoscaling.studio.enabled }}
   replicas: {{ .Values.deployment.studio.replicaCount }}
   {{- end }}
+  {{- with .Values.deployment.studio.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "supabase.studio.selectorLabels" . | nindent 6 }}

--- a/charts/supabase/values.yaml
+++ b/charts/supabase/values.yaml
@@ -508,6 +508,11 @@ deployment:
     resources: {}
     volumeMounts: {}
     volumes: {}
+    ## Deployment strategy. Set to {type: Recreate} when using persistence.snippets
+    ## with a ReadWriteOnce PVC: the chart's default RollingUpdate causes a
+    ## Multi-Attach error because the new pod is scheduled before the old one
+    ## releases the volume. Studio is single-replica so the brief gap is fine.
+    strategy: {}
 
   vector:
     enabled: true


### PR DESCRIPTION
## Summary

Allow users to set the Deployment update strategy on Studio via `deployment.studio.strategy`.

## Motivation

The chart currently leaves Studio's update strategy at the K8s default `RollingUpdate`, which conflicts with `persistence.snippets` when the underlying PVC is `ReadWriteOnce` (the chart's default):

1. ArgoCD/Helm rolls out a new Studio Deployment revision.
2. K8s creates the new pod *before* terminating the old one (RollingUpdate, maxSurge=25%, single replica).
3. The new pod tries to attach the snippets PVC — but the old pod still holds it.
4. Kubelet reports `FailedAttachVolume — Multi-Attach error for volume "..."`. The new pod stays Pending until someone manually deletes the old pod.

This happens on every rollout — chart bumps, image bumps, values edits — and quietly breaks `persistence.snippets` for anyone using the default ReadWriteOnce PVC. The only workaround today is to either:

- Disable `persistence.snippets` entirely (losing snippet storage), or
- Provide a ReadWriteMany volume (requires EFS/NFS).

With this PR users can set:

```yaml
deployment:
  studio:
    strategy:
      type: Recreate
```

…so the old pod terminates before the new one starts, releasing the PVC. Studio is single-replica by default, so the brief gap during rollout is acceptable.

## Behavior

- **Default users:** No change. Without setting `strategy`, the chart emits no `strategy:` block and K8s applies its default (RollingUpdate / 25% surge).
- **Override users:** Whatever they put under `deployment.studio.strategy` is rendered into the Deployment's `spec.strategy`. Standard Helm `with`/`toYaml` pattern, consistent with how the chart handles other free-form blocks (`resources`, `nodeSelector`, `affinity`, etc.).

## Test plan

- [x] `helm template` with no override → no `strategy:` block in rendered Studio Deployment, K8s defaults apply
- [x] `helm template` with `deployment.studio.strategy.type: Recreate` → rendered Deployment contains:
  ```yaml
  spec:
    replicas: 1
    strategy:
      type: Recreate
    selector:
      ...
  ```
- [x] Verified against `supabase-0.5.6` baseline in a real ArgoCD deployment where the ReadWriteOnce PVC contention was reproducing on every rollout.

## Diff

```diff
# templates/studio/deployment.yaml
 spec:
   {{- if not .Values.autoscaling.studio.enabled }}
   replicas: {{ .Values.deployment.studio.replicaCount }}
   {{- end }}
+  {{- with .Values.deployment.studio.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
```

```diff
# values.yaml — deployment.studio
     volumeMounts: {}
     volumes: {}
+    ## Deployment strategy. Set to {type: Recreate} when using persistence.snippets
+    ## with a ReadWriteOnce PVC: the chart's default RollingUpdate causes a
+    ## Multi-Attach error because the new pod is scheduled before the old one
+    ## releases the volume. Studio is single-replica so the brief gap is fine.
+    strategy: {}
```