### PR TITLE
feat(kong, functions): roll pod on config change via checksum/config annotation

### DIFF
--- a/charts/supabase/templates/functions/deployment.yaml
+++ b/charts/supabase/templates/functions/deployment.yaml
@@ -21,10 +21,16 @@ spec:
     metadata:
       labels:
         {{- include "supabase.functions.selectorLabels" . | nindent 8 }}
-      {{- with .Values.deployment.functions.podAnnotations }}
       annotations:
+        # Roll the functions pod whenever the bundled "main" router source
+        # changes (files/functions/index.ts). Without this, chart bumps that
+        # update the router silently leave running pods on the old code.
+        # Matches the pattern already used by the vector Deployment in this
+        # chart.
+        checksum/config: {{ .Files.Get "files/functions/index.ts" | sha256sum }}
+        {{- with .Values.deployment.functions.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "supabase.functions.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.deployment.functions.automountServiceAccountToken }}

--- a/charts/supabase/templates/kong/deployment.yaml
+++ b/charts/supabase/templates/kong/deployment.yaml
@@ -21,10 +21,17 @@ spec:
     metadata:
       labels:
         {{- include "supabase.kong.selectorLabels" . | nindent 8 }}
-      {{- with .Values.deployment.kong.podAnnotations }}
       annotations:
+        # Roll the Kong pod whenever its routing config changes. Without this,
+        # toggling any deployment.<svc>.enabled (which adds/removes Kong routes)
+        # silently leaves Kong running with stale config until something else
+        # forces a roll. Matches the pattern already used by the vector
+        # Deployment in this chart.
+        # https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
+        checksum/config: {{ tpl (.Files.Get "files/kong/kong.yml") . | sha256sum }}
+        {{- with .Values.deployment.kong.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "supabase.kong.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.deployment.kong.automountServiceAccountToken }}


### PR DESCRIPTION
## Summary

Add a `checksum/config` annotation to the Kong and Functions pod templates so they roll automatically when their mounted ConfigMaps change. Matches the pattern already used by the vector Deployment in this chart.

## Motivation

Kong's Deployment mounts a ConfigMap (`kong.yml` rendered from `files/kong/kong.yml`) containing routes for every enabled Supabase service. The Functions Deployment mounts a ConfigMap holding `files/functions/index.ts` (the bundled \"main\" router source). Neither pod template carries a `checksum/config` annotation today, so when the ConfigMap content changes the Deployment's pod template is unchanged → kubelet keeps the running pod on its old mounted config until something else forces a roll.

**Concrete bite from a real install:** a release that flips `deployment.functions.enabled` from `false` to `true` adds a `/functions/v1/*` route to Kong's ConfigMap, but Kong stays on its previous config indefinitely. Every request to `/functions/v1/*` returns Kong's generic `Unauthorized` (route doesn't exist) until the operator manually `kubectl rollout restart deploy/<release>-supabase-kong`. Same shape on every subsequent enable/disable.

## Behavior

- **Kong:** pod rolls iff the rendered `kong.yml` content changes. Adding a service, removing a service, changing kong's plugins/timeouts now triggers a clean roll on the next sync.
- **Functions:** pod rolls iff `files/functions/index.ts` content changes (chart upgrades that update the bundled router are now picked up on sync without manual intervention).
- **Users with no ConfigMap-affecting changes between releases:** zero behavioral difference, no extra rolls — the checksum is stable.

## Test plan

Verified via `helm template` against the chart with two value sets:

```
# deployment.functions.enabled: false  →
checksum/config: 8b4cf2e2483c1d1732e04051b72967712abfbd76e7d92f9dcd38cb4bb2e4eda0
functions-v1 references in rendered kong configmap: 0

# deployment.functions.enabled: true   →
checksum/config: a382fa6185cb5ccc5cd12bdb211dc527f47b88b23ddaf32202e34eb9b0972843
functions-v1 references in rendered kong configmap: 2
```

Different checksums when the rendered Kong config differs → pod rolls. Identical when the config doesn't change → no churn.

## Diff

```diff
# templates/kong/deployment.yaml
   template:
     metadata:
       labels:
         {{- include \"supabase.kong.selectorLabels\" . | nindent 8 }}
-      {{- with .Values.deployment.kong.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        checksum/config: {{ tpl (.Files.Get \"files/kong/kong.yml\") . | sha256sum }}
+        {{- with .Values.deployment.kong.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
```

```diff
# templates/functions/deployment.yaml
   template:
     metadata:
       labels:
         {{- include \"supabase.functions.selectorLabels\" . | nindent 8 }}
-      {{- with .Values.deployment.functions.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        checksum/config: {{ .Files.Get \"files/functions/index.ts\" | sha256sum }}
+        {{- with .Values.deployment.functions.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
```

Reference: https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments