### PR TITLE
feat(db): add persistent pgsodium volume mounted at /etc/postgresql-custom

### DIFF
--- a/charts/supabase/templates/db/statefulset.yaml
+++ b/charts/supabase/templates/db/statefulset.yaml
@@ -53,6 +53,22 @@ spec:
       priorityClassName: {{ . }}
       {{- end }}
       initContainers:
+        - name: init-pgsodium
+          image: "{{ .Values.image.db.repository }}:{{ .Values.image.db.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.db.pullPolicy }}
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              echo "Initializing pgsodium persistent config directory..."
+              if [ -z "$(ls -A /mnt/pgsodium 2>/dev/null)" ]; then
+                echo "pgsodium volume is empty, copying default postgresql-custom files..."
+                cp -a /etc/postgresql-custom/. /mnt/pgsodium/
+              else
+                echo "pgsodium volume already initialized, skipping copy"
+              fi
+          volumeMounts:
+            - mountPath: /mnt/pgsodium
+              name: pgsodium
         - name: init-db
           image: "{{ .Values.image.db.repository }}:{{ .Values.image.db.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.db.pullPolicy }}
@@ -132,6 +148,10 @@ spec:
           volumeMounts:
             - mountPath: /docker-entrypoint-initdb.d
               name: initdb-scripts-data
+            {{- if .Values.persistence.pgsodium.enabled }}
+            - mountPath: /etc/postgresql-custom
+              name: pgsodium
+            {{- end }}
             {{- with .Values.deployment.db.volumeMounts }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -171,6 +191,11 @@ spec:
         - name: custom-migrations
           configMap:
             name: {{ include "supabase.db.fullname" . }}-migrations
+        {{- if .Values.persistence.pgsodium.enabled }}
+        - name: pgsodium
+          persistentVolumeClaim:
+            claimName: {{ include "supabase.pvc.name" (dict "root" $ "name" "pgsodium") }}
+        {{- end }}
         {{- with .Values.deployment.db.volumes }}
           {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/supabase/templates/persistence.yaml
+++ b/charts/supabase/templates/persistence.yaml
@@ -1,5 +1,7 @@
 {{ include "supabase.pvc" (dict "root" $ "name" "db" "enabled" .Values.deployment.db.enabled) }}
 ---
+{{ include "supabase.pvc" (dict "root" $ "name" "pgsodium" "enabled" .Values.deployment.db.enabled) }}
+---
 {{ include "supabase.pvc" (dict "root" $ "name" "functions" "enabled" .Values.deployment.functions.enabled) }}
 ---
 {{ include "supabase.pvc" (dict "root" $ "name" "imgproxy" "enabled" .Values.deployment.imgproxy.enabled) }}

--- a/charts/supabase/values.yaml
+++ b/charts/supabase/values.yaml
@@ -842,6 +842,15 @@ persistence:
     accessModes:
       - ReadWriteOnce
 
+  pgsodium:
+    enabled: true
+    storageClassName: ""
+    # existingClaim: ""
+    annotations: {}
+    size: 100Mi
+    accessModes:
+      - ReadWriteOnce
+
 service:
   analytics:
     type: ClusterIP


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The db StatefulSet did not have a persistent volume mounted at `/etc/postgresql-custom`. Because pgsodium generates its key inside that directory, every pod restart caused a new key to be generated, breaking encryption consistency for databases that already relied on the previous key.

## What is the new behavior?

- Added a new persistent volume claim (`pgsodium`) via `values.yaml` and `templates/persistence.yaml`.
- Mounted the `pgsodium` PVC in the db StatefulSet at `/etc/postgresql-custom`.
- Added an `init-pgsodium` init container that seeds the PVC with the original files from the Docker image on first boot, then skips copying on subsequent restarts to preserve the generated pgsodium key. The pgsodium key is now persisted across pod restarts.

## Additional context

The init container uses `cp -a /etc/postgresql-custom/. /mnt/pgsodium/` to preserve permissions and only runs when the volume is empty. Default PVC size is `100Mi` with `ReadWriteOnce`, following the existing persistence pattern used by other components in this chart. 