### PR TITLE
feat: add deployment.<component>.extraEnv for arbitrary container env vars

### DIFF
--- a/charts/supabase/templates/analytics/deployment.yaml
+++ b/charts/supabase/templates/analytics/deployment.yaml
@@ -111,6 +111,9 @@ spec:
             - name: POSTGRES_BACKEND_URL
               value: $(DB_DRIVER)://$(DB_USERNAME):$(DB_PASSWORD_ENC)@$(DB_HOSTNAME):$(DB_PORT)/$(DB_DATABASE)
             {{- end }}
+            {{- with .Values.deployment.analytics.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- with .Values.deployment.analytics.envFrom }}
           envFrom:
             {{- toYaml . | nindent 12 }}

--- a/charts/supabase/templates/auth/deployment.yaml
+++ b/charts/supabase/templates/auth/deployment.yaml
@@ -128,6 +128,9 @@ spec:
                 secretKeyRef:
                   name: {{ include "supabase.secret.smtp.name" . }}
                   key: {{ include "supabase.secret.smtp.key.password" . }}
+            {{- with .Values.deployment.auth.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- with .Values.deployment.auth.envFrom }}
           envFrom:
             {{- toYaml . | nindent 12 }}

--- a/charts/supabase/templates/db/statefulset.yaml
+++ b/charts/supabase/templates/db/statefulset.yaml
@@ -137,6 +137,9 @@ spec:
                 secretKeyRef:
                   name: {{ include "supabase.secret.jwt.name" . }}
                   key: {{ include "supabase.secret.jwt.key.secret" . }}
+            {{- with .Values.deployment.db.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- with .Values.deployment.db.envFrom }}
           envFrom:
             {{- toYaml . | nindent 12 }}

--- a/charts/supabase/templates/functions/deployment.yaml
+++ b/charts/supabase/templates/functions/deployment.yaml
@@ -130,6 +130,9 @@ spec:
               value: '{"default":"$(SUPABASE_SECRET_KEY)"}'
             - name: SUPABASE_DB_URL
               value: $(DB_DRIVER)://$(DB_USERNAME):$(DB_PASSWORD_ENC)@$(DB_HOSTNAME):$(DB_PORT)/$(DB_DATABASE)?search_path=auth&sslmode=$(DB_SSL)
+            {{- with .Values.deployment.functions.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- if .Values.deployment.functions.envFrom }}
           envFrom:
             {{- toYaml .Values.deployment.functions.envFrom | nindent 12 }}

--- a/charts/supabase/templates/imgproxy/deployment.yaml
+++ b/charts/supabase/templates/imgproxy/deployment.yaml
@@ -64,6 +64,9 @@ spec:
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
+            {{- with .Values.deployment.imgproxy.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- with .Values.deployment.imgproxy.envFrom }}
           envFrom:
             {{- toYaml . | nindent 12 }}

--- a/charts/supabase/templates/kong/deployment.yaml
+++ b/charts/supabase/templates/kong/deployment.yaml
@@ -115,6 +115,9 @@ spec:
                   name: {{ include "supabase.secret.dashboard.name" . }}
                   key: {{ include "supabase.secret.dashboard.key.password" . }}
             {{- end }}
+            {{- with .Values.deployment.kong.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- with .Values.deployment.kong.envFrom }}
           envFrom:
             {{- toYaml . | nindent 12 }}

--- a/charts/supabase/templates/meta/deployment.yaml
+++ b/charts/supabase/templates/meta/deployment.yaml
@@ -99,6 +99,9 @@ spec:
                 secretKeyRef:
                   name: {{ include "supabase.secret.meta.name" . }}
                   key: {{ include "supabase.secret.meta.key.cryptoKey" . }}
+            {{- with .Values.deployment.meta.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- with .Values.deployment.meta.envFrom }}
           envFrom:
             {{- toYaml . | nindent 12 }}

--- a/charts/supabase/templates/minio/deployment.yaml
+++ b/charts/supabase/templates/minio/deployment.yaml
@@ -80,6 +80,9 @@ spec:
                   name: {{ include "supabase.secret.minio.name" . }}
                   key: {{ include "supabase.secret.minio.key.password" . }}
                   {{- end }}
+            {{- with .Values.deployment.minio.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- with .Values.deployment.minio.envFrom }}
           envFrom:
             {{- toYaml . | nindent 12 }}

--- a/charts/supabase/templates/realtime/deployment.yaml
+++ b/charts/supabase/templates/realtime/deployment.yaml
@@ -124,6 +124,9 @@ spec:
                 secretKeyRef:
                   name: {{ include "supabase.secret.realtime.name" . }}
                   key: {{ include "supabase.secret.realtime.key.secretKeyBase" . }}
+            {{- with .Values.deployment.realtime.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- with .Values.deployment.realtime.envFrom }}
           envFrom:
             {{- toYaml . | nindent 12 }}

--- a/charts/supabase/templates/rest/deployment.yaml
+++ b/charts/supabase/templates/rest/deployment.yaml
@@ -119,6 +119,9 @@ spec:
                 secretKeyRef:
                   name: {{ include "supabase.secret.jwt.name" . }}
                   key: {{ include "supabase.secret.jwt.key.secret" . }}
+            {{- with .Values.deployment.rest.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- with .Values.deployment.rest.envFrom }}
           envFrom:
             {{- toYaml . | nindent 12 }}

--- a/charts/supabase/templates/storage/deployment.yaml
+++ b/charts/supabase/templates/storage/deployment.yaml
@@ -228,6 +228,9 @@ spec:
             - name: GLOBAL_S3_FORCE_PATH_STYLE
               value: "true"
             {{- end }}
+            {{- with .Values.deployment.storage.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- with .Values.deployment.storage.envFrom }}
           envFrom:
             {{- toYaml . | nindent 12 }}

--- a/charts/supabase/templates/studio/deployment.yaml
+++ b/charts/supabase/templates/studio/deployment.yaml
@@ -153,6 +153,9 @@ spec:
             - name: SNIPPETS_MANAGEMENT_FOLDER
               value: /app/snippets
             {{- end }}
+            {{- with .Values.deployment.studio.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- with .Values.deployment.studio.envFrom }}
           envFrom:
             {{- toYaml . | nindent 12 }}

--- a/charts/supabase/templates/vector/deployment.yaml
+++ b/charts/supabase/templates/vector/deployment.yaml
@@ -79,6 +79,9 @@ spec:
                   name: {{ include "supabase.secret.analytics.name" . }}
                   key: {{ include "supabase.secret.analytics.key.publicAccessToken" . }}
             {{- end }}
+            {{- with .Values.deployment.vector.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- with .Values.deployment.vector.envFrom }}
           envFrom:
             {{- toYaml . | nindent 12 }}

--- a/charts/supabase/values.yaml
+++ b/charts/supabase/values.yaml
@@ -235,6 +235,7 @@ deployment:
     tolerations: []
     priorityClassName: ""
     envFrom: []
+    extraEnv: []
     livenessProbe: {}
     readinessProbe: {}
     startupProbe: {}
@@ -259,6 +260,7 @@ deployment:
     tolerations: []
     priorityClassName: ""
     envFrom: []
+    extraEnv: []
     livenessProbe: {}
     readinessProbe: {}
     startupProbe: {}
@@ -283,6 +285,7 @@ deployment:
     tolerations: []
     priorityClassName: ""
     envFrom: []
+    extraEnv: []
     livenessProbe: {}
     readinessProbe: {}
     startupProbe: {}
@@ -308,6 +311,7 @@ deployment:
     tolerations: []
     priorityClassName: ""
     envFrom: []
+    extraEnv: []
     livenessProbe: {}
     readinessProbe: {}
     startupProbe: {}
@@ -332,6 +336,7 @@ deployment:
     tolerations: []
     priorityClassName: ""
     envFrom: []
+    extraEnv: []
     livenessProbe: {}
     readinessProbe: {}
     startupProbe: {}
@@ -356,6 +361,7 @@ deployment:
     tolerations: []
     priorityClassName: ""
     envFrom: []
+    extraEnv: []
     livenessProbe: {}
     readinessProbe: {}
     startupProbe: {}
@@ -380,6 +386,7 @@ deployment:
     tolerations: []
     priorityClassName: ""
     envFrom: []
+    extraEnv: []
     livenessProbe: {}
     readinessProbe: {}
     startupProbe: {}
@@ -404,6 +411,7 @@ deployment:
     tolerations: []
     priorityClassName: ""
     envFrom: []
+    extraEnv: []
     livenessProbe: {}
     readinessProbe: {}
     startupProbe: {}
@@ -428,6 +436,7 @@ deployment:
     tolerations: []
     priorityClassName: ""
     envFrom: []
+    extraEnv: []
     livenessProbe: {}
     readinessProbe: {}
     startupProbe: {}
@@ -452,6 +461,7 @@ deployment:
     tolerations: []
     priorityClassName: ""
     envFrom: []
+    extraEnv: []
     livenessProbe: {}
     readinessProbe: {}
     startupProbe: {}
@@ -476,6 +486,7 @@ deployment:
     tolerations: []
     priorityClassName: ""
     envFrom: []
+    extraEnv: []
     livenessProbe: {}
     readinessProbe: {}
     startupProbe: {}
@@ -501,6 +512,7 @@ deployment:
     tolerations: []
     priorityClassName: ""
     envFrom: []
+    extraEnv: []
     livenessProbe: {}
     readinessProbe: {}
     startupProbe: {}
@@ -530,6 +542,7 @@ deployment:
     tolerations: []
     priorityClassName: ""
     envFrom: []
+    extraEnv: []
     livenessProbe: {}
     readinessProbe: {}
     startupProbe: {}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature (opt-in).

## What is the current behavior?

Closes #200. Deployments expose `environment.<component>` (plain values) and `envFrom`, but there's no way to inject a named env var via `valueFrom` (e.g. an OAuth provider secret from a Secret key).

## What is the new behavior?

Adds `deployment.<component>.extraEnv`, a raw env list appended to each container's `env` (supports `valueFrom`), as the sibling of the existing `envFrom`. Applied to all workload deployments; default empty, no behavior change.

## Additional context

`helm lint` passes; default render unchanged.
