### PR TITLE
Fix external DB init hook order

### DIFF
--- a/charts/supabase/templates/db/init-external-config.yaml
+++ b/charts/supabase/templates/db/init-external-config.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
     "helm.sh/hook-delete-policy": before-hook-creation
     argocd.argoproj.io/hook: PreSync

--- a/charts/supabase/templates/db/init-external-job.yaml
+++ b/charts/supabase/templates/db/init-external-job.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": before-hook-creation
     argocd.argoproj.io/hook: PreSync


### PR DESCRIPTION
Run external DB init as a pre-install/pre-upgrade hook.

This lets Helm create the init ConfigMap and wait for the init Job before Supabase Deployments start, avoiding pending installs when deployment.db.enabled=false.