### PR TITLE
feat(storage, functions, imgproxy, minio): expose deployment.<svc>.strategy

### DIFF
--- a/charts/supabase/templates/functions/deployment.yaml
+++ b/charts/supabase/templates/functions/deployment.yaml
@@ -14,6 +14,10 @@ spec:
   {{- if not .Values.autoscaling.functions.enabled }}
   replicas: {{ .Values.deployment.functions.replicaCount }}
   {{- end }}
+  {{- with .Values.deployment.functions.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "supabase.functions.selectorLabels" . | nindent 6 }}

--- a/charts/supabase/templates/imgproxy/deployment.yaml
+++ b/charts/supabase/templates/imgproxy/deployment.yaml
@@ -14,6 +14,10 @@ spec:
   {{- if not .Values.autoscaling.imgproxy.enabled }}
   replicas: {{ .Values.deployment.imgproxy.replicaCount }}
   {{- end }}
+  {{- with .Values.deployment.imgproxy.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "supabase.imgproxy.selectorLabels" . | nindent 6 }}

--- a/charts/supabase/templates/minio/deployment.yaml
+++ b/charts/supabase/templates/minio/deployment.yaml
@@ -14,6 +14,10 @@ spec:
   {{- if not .Values.autoscaling.minio.enabled }}
   replicas: {{ .Values.deployment.minio.replicaCount }}
   {{- end }}
+  {{- with .Values.deployment.minio.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "supabase.minio.selectorLabels" . | nindent 6 }}

--- a/charts/supabase/templates/storage/deployment.yaml
+++ b/charts/supabase/templates/storage/deployment.yaml
@@ -14,6 +14,10 @@ spec:
   {{- if not .Values.autoscaling.storage.enabled }}
   replicas: {{ .Values.deployment.storage.replicaCount }}
   {{- end }}
+  {{- with .Values.deployment.storage.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "supabase.storage.selectorLabels" . | nindent 6 }}

--- a/charts/supabase/values.yaml
+++ b/charts/supabase/values.yaml
@@ -315,6 +315,11 @@ deployment:
     resources: {}
     volumeMounts: {}
     volumes: {}
+    ## Deployment strategy. Set to {type: Recreate} when using
+    ## persistence.functions.enabled with a ReadWriteOnce PVC: the chart's
+    ## default RollingUpdate causes a Multi-Attach error because the new
+    ## pod is scheduled before the old one releases the volume.
+    strategy: {}
 
   imgproxy:
     enabled: true
@@ -339,6 +344,11 @@ deployment:
     resources: {}
     volumeMounts: {}
     volumes: {}
+    ## Deployment strategy. Set to {type: Recreate} when using
+    ## persistence.imgproxy.enabled with a ReadWriteOnce PVC: the chart's
+    ## default RollingUpdate causes a Multi-Attach error because the new
+    ## pod is scheduled before the old one releases the volume.
+    strategy: {}
 
   kong:
     enabled: true
@@ -411,6 +421,11 @@ deployment:
     resources: {}
     volumeMounts: {}
     volumes: {}
+    ## Deployment strategy. Set to {type: Recreate} when using
+    ## persistence.minio.enabled with a ReadWriteOnce PVC: the chart's
+    ## default RollingUpdate causes a Multi-Attach error because the new
+    ## pod is scheduled before the old one releases the volume.
+    strategy: {}
 
   realtime:
     enabled: true
@@ -483,6 +498,11 @@ deployment:
     resources: {}
     volumeMounts: {}
     volumes: {}
+    ## Deployment strategy. Set to {type: Recreate} when using
+    ## persistence.storage.enabled with a ReadWriteOnce PVC: the chart's
+    ## default RollingUpdate causes a Multi-Attach error because the new
+    ## pod is scheduled before the old one releases the volume.
+    strategy: {}
     extraInitContainers: []
 
   studio:


### PR DESCRIPTION
## Summary

Add Deployment update-strategy support to the four services that mount ReadWriteOnce PVCs by default. Same pattern (and same motivation) as #195 for studio, now extended to the remaining deployments that hit Multi-Attach contention on rollout.

## Motivation

When the chart bumps and one of these services' Deployment spec changes, the default `RollingUpdate` schedules the new pod *before* terminating the old one. The new pod tries to attach the RWO PVC the old one still holds → kubelet reports `FailedAttachVolume — Multi-Attach error`, the new pod stays Pending indefinitely until someone manually `kubectl delete pod` on the old one.

Reproduced today during a `0.5.6 → 0.5.7` chart bump in a real ArgoCD install: `supabase-storage` Deployment rolled, new pod stuck on `Init:0/1` for 5+ hours on prd until manual intervention. Two clusters, identical behavior. Same shape would apply to `functions`, `imgproxy`, `minio` whenever their persistence is enabled, which is the default.

After this PR users can set, per affected service:

```yaml
deployment:
  storage:
    strategy:
      type: Recreate
```

…so the old pod terminates before the new one starts, releasing the PVC. All four services default to `replicaCount: 1`, so the brief gap during a roll is acceptable. Consistent with #195 (`deployment.studio.strategy`).

## Behavior

- **Default users (`strategy` unset):** No change. The chart emits no `strategy:` block; K8s applies its default (RollingUpdate, 25% surge).
- **Override users:** Whatever is provided under `deployment.<svc>.strategy` renders into `spec.strategy`. Standard `with`/`toYaml` pattern, consistent with #195.

## Test plan

Verified via `helm template` against the chart with two value sets:

```
# baseline (no override) — storage Deployment:
spec:
  replicas: 1
  selector:
    ...

# with deployment.storage.strategy.type: Recreate — storage Deployment:
spec:
  replicas: 1
  strategy:
    type: Recreate
  selector:
    ...
```

Same shape verified for functions, imgproxy, minio in the same render.

## Diff (one file per service — same 4-line block in each)

```diff
# templates/<svc>/deployment.yaml
 spec:
   {{- if not .Values.autoscaling.<svc>.enabled }}
   replicas: {{ .Values.deployment.<svc>.replicaCount }}
   {{- end }}
+  {{- with .Values.deployment.<svc>.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
```

```diff
# values.yaml — deployment.<svc> (storage, functions, imgproxy, minio)
     volumeMounts: {}
     volumes: {}
+    ## Deployment strategy. Set to {type: Recreate} when using
+    ## persistence.<svc>.enabled with a ReadWriteOnce PVC: the chart's
+    ## default RollingUpdate causes a Multi-Attach error because the new
+    ## pod is scheduled before the old one releases the volume.
+    strategy: {}
```

Closes the operational gap left after #195 (which only covered studio).