### PR TITLE
feat(realtime): expose deployment.realtime.runSeeds to gate non-idempotent seed eval

### DIFF
--- a/charts/supabase/templates/realtime/deployment.yaml
+++ b/charts/supabase/templates/realtime/deployment.yaml
@@ -71,7 +71,14 @@ spec:
           image: "{{ .Values.image.realtime.repository }}:{{ .Values.image.realtime.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.realtime.pullPolicy }}
           command: ["/bin/sh"]
-          args: ["-c", "/app/bin/migrate && /app/bin/realtime eval 'Realtime.Release.seeds(Realtime.Repo)' && /app/bin/server"]
+          args:
+            - "-c"
+            - >-
+              /app/bin/migrate &&
+              {{- if .Values.deployment.realtime.runSeeds }}
+              /app/bin/realtime eval 'Realtime.Release.seeds(Realtime.Repo)' &&
+              {{- end }}
+              /app/bin/server
           ports:
             - name: http
               containerPort: 4000

--- a/charts/supabase/values.yaml
+++ b/charts/supabase/values.yaml
@@ -435,6 +435,16 @@ deployment:
     resources: {}
     volumeMounts: {}
     volumes: {}
+    ## Run Realtime.Release.seeds(Realtime.Repo) on every container start.
+    ## Default true preserves existing behavior, but the seed step deletes
+    ## and recreates the tenant row on every pod restart (see
+    ## supabase/realtime priv/repo/seeds.exs). Recreation clobbers any
+    ## tenant config edited via the management API and the hardcoded
+    ## "ssl_enforced": false breaks tenant CDC against TLS-only Postgres
+    ## (e.g. AWS RDS with rds.force_ssl=1). Set to false after the tenant
+    ## has been seeded once, or on every install where the tenant already
+    ## exists in the metadata DB.
+    runSeeds: true
 
   rest:
     enabled: true


### PR DESCRIPTION
## Summary

Adds `deployment.realtime.runSeeds` (default `true`, preserves current behavior) so operators can skip the realtime container's unconditional seed eval after the tenant has been seeded once.

## Motivation

The realtime container's args currently run `Realtime.Release.seeds(Realtime.Repo)` on **every pod start**:

```yaml
args: [\"-c\", \"/app/bin/migrate && /app/bin/realtime eval 'Realtime.Release.seeds(Realtime.Repo)' && /app/bin/server\"]
```

That eval runs supabase/realtime's [`priv/repo/seeds.exs`](https://github.com/supabase/realtime/blob/main/priv/repo/seeds.exs), which:

1. `DELETE`s the existing `_realtime.tenants` row
2. `INSERT`s a fresh tenant with **hardcoded** settings (`\"ssl_enforced\": false`, default `jwt_secret`, etc.)
3. Runs tenant migrations against the freshly-recreated tenant

Fine on first install. **Every subsequent pod restart** (image bump, helm upgrade, node reschedule, `kubectl rollout restart`) wipes any tenant config edited via the management API or directly in the DB. Most consequentially for self-hosters on managed Postgres: the hardcoded `\"ssl_enforced\": false` breaks tenant CDC against TLS-only Postgres (AWS RDS with `rds.force_ssl=1`, GCP Cloud SQL with **Require SSL/TLS connections**) with `FATAL 28000 no pg_hba.conf entry … no encryption`, no matter what an operator sets the field to in the DB — the next pod restart resets it.

Companion PR [supabase/realtime#1970](https://github.com/supabase/realtime/pull/1970) makes `ssl_enforced` configurable at seed time via `DB_SSL_ENFORCED` env. That solves the immediate SSL case, but doesn't address the broader non-idempotency: seeds.exs is destructive-on-every-boot, and the chart triggers it on every boot. The right chart-side fix is to make the seed gated, so operators can run it once and turn it off.

## Behavior

- **Default users (`runSeeds` unset / true):** No change. Args still include the seed eval; existing installs keep working identically.
- **Override users (`runSeeds: false`):** The chart emits `args` without the seed eval. Container runs `migrate && server` only. Tenant remains as-is in the metadata DB.

Typical lifecycle:
1. Install chart, `runSeeds: true` (default). Pod boots, seed populates `_realtime.tenants`.
2. Operator flips `runSeeds: false` in values.
3. From then on, pod restarts don't clobber the tenant row.

## Diff

```diff
# templates/realtime/deployment.yaml
-          args: [\"-c\", \"/app/bin/migrate && /app/bin/realtime eval 'Realtime.Release.seeds(Realtime.Repo)' && /app/bin/server\"]
+          args:
+            - \"-c\"
+            - >-
+              /app/bin/migrate &&
+              {{- if .Values.deployment.realtime.runSeeds }}
+              /app/bin/realtime eval 'Realtime.Release.seeds(Realtime.Repo)' &&
+              {{- end }}
+              /app/bin/server
```

```diff
# values.yaml — deployment.realtime
     volumeMounts: {}
     volumes: {}
+    ## Run Realtime.Release.seeds(Realtime.Repo) on every container start.
+    ## Default true preserves existing behavior, but the seed step deletes
+    ## and recreates the tenant row on every pod restart (see
+    ## supabase/realtime priv/repo/seeds.exs). Recreation clobbers any
+    ## tenant config edited via the management API and the hardcoded
+    ## \"ssl_enforced\": false breaks tenant CDC against TLS-only Postgres
+    ## (e.g. AWS RDS with rds.force_ssl=1). Set to false after the tenant
+    ## has been seeded once, or on every install where the tenant already
+    ## exists in the metadata DB.
+    runSeeds: true
```

## Test plan

Verified via `helm template`:

```
# Default (runSeeds: true) — args include the seed eval:
args:
  - \"-c\"
  - >-
    /app/bin/migrate &&
    /app/bin/realtime eval 'Realtime.Release.seeds(Realtime.Repo)' &&
    /app/bin/server

# runSeeds: false — seed eval omitted:
args:
  - \"-c\"
  - >-
    /app/bin/migrate &&
    /app/bin/server
```