### PR TITLE
feat(db): support referencing an existing migrations ConfigMap

### DIFF
--- a/charts/supabase/templates/db/_helpers.tpl
+++ b/charts/supabase/templates/db/_helpers.tpl
@@ -24,6 +24,19 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{/*
+Name of the ConfigMap holding user-defined migration scripts.
+If migrationConfigRef is set, that existing ConfigMap is referenced and the
+chart will not render its own migrations ConfigMap.
+*/}}
+{{- define "supabase.db.migrationsConfigMap.name" -}}
+{{- if .Values.migrationConfigRef -}}
+{{- .Values.migrationConfigRef -}}
+{{- else -}}
+{{- printf "%s-migrations" (include "supabase.db.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Selector labels
 */}}
 {{- define "supabase.db.selectorLabels" -}}

--- a/charts/supabase/templates/db/migration.config.yaml
+++ b/charts/supabase/templates/db/migration.config.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.deployment.db.enabled -}}
+{{- if and .Values.deployment.db.enabled (not .Values.migrationConfigRef) -}}
 kind: ConfigMap
 apiVersion: v1
 metadata:

--- a/charts/supabase/templates/db/statefulset.yaml
+++ b/charts/supabase/templates/db/statefulset.yaml
@@ -190,7 +190,7 @@ spec:
             name: {{ include "supabase.db.fullname" . }}-initdb
         - name: custom-migrations
           configMap:
-            name: {{ include "supabase.db.fullname" . }}-migrations
+            name: {{ include "supabase.db.migrationsConfigMap.name" . }}
         {{- if .Values.persistence.pgsodium.enabled }}
         - name: pgsodium
           persistentVolumeClaim:

--- a/charts/supabase/values.yaml
+++ b/charts/supabase/values.yaml
@@ -1171,6 +1171,11 @@ networkPolicy:
     #         matchLabels:
     #           role: analyst-tool
 
+## Reference to an existing ConfigMap holding migration scripts.
+## When set, the chart will not create its own migrations ConfigMap and the
+## referenced ConfigMap is mounted instead (overriding `migration` below).
+# migrationConfigRef: ""
+
 migration:
   # example.sql: |
   #   \set pguser `echo "$POSTGRES_USER"`


### PR DESCRIPTION
Add an optional `migrationConfigRef` value that points the db StatefulSet at an existing ConfigMap of migration scripts. When set, the chart no longer renders its own migrations ConfigMap, mirroring the `secret.*.secretRef` pattern used elsewhere in the chart.

## What kind of change does this PR introduce?

feature

## What is the current behavior?

A ConfigMap named `$(supabase.db.fullname)-migrations` is automatically created, and migration sql is mounted in it. The SQL must be inlined under the `Values.yaml` file, and using an external `.sql` file is impossible.

## What is the new behavior?

Allows to externalize creation of the `ConfigMap` storing migrations. This permits users to either upload ConfigMap before the helm chart, or to use Kustomize's `configMapGenerator` to mount an actual .sql file instead of inlining sql data inside Values.

The change is backwards compatible, and users can still inline migrations if they wish to.
