### PR TITLE
feat(functions): expose deployment.functions.strategy

### DIFF
--- a/charts/supabase/templates/functions/deployment.yaml
+++ b/charts/supabase/templates/functions/deployment.yaml
@@ -14,6 +14,10 @@ spec:
   {{- if not .Values.autoscaling.functions.enabled }}
   replicas: {{ .Values.deployment.functions.replicaCount }}
   {{- end }}
+  {{- with .Values.deployment.functions.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "supabase.functions.selectorLabels" . | nindent 6 }}

--- a/charts/supabase/values.yaml
+++ b/charts/supabase/values.yaml
@@ -315,6 +315,7 @@ deployment:
     resources: {}
     volumeMounts: {}
     volumes: {}
+    strategy: {}
 
   imgproxy:
     enabled: true


### PR DESCRIPTION
## Summary

- Add `deployment.functions.strategy` to `values.yaml` so Edge Functions rollout strategy can be configured (e.g. `Recreate` for single-replica deployments with RWO volumes).
- Render the strategy block in the functions Deployment template, following the same pattern already used for studio and other workloads.

## Motivation

When running Edge Functions with persistent volumes or init containers that cannot tolerate two pods at once, the default `RollingUpdate` strategy can block rollouts. Exposing `strategy` makes it possible to set `type: Recreate` without patching the rendered manifest.

## Test plan

- [ ] `helm template` renders without errors with default empty `strategy: {}`
- [ ] `helm template` with `deployment.functions.strategy.type: Recreate` produces the expected strategy block
- [ ] Deploy to a cluster and verify functions pod rolls out correctly