### PR TITLE
feat(chart): add configurable ServiceMonitor support

### DIFF
--- a/charts/supabase/Chart.yaml
+++ b/charts/supabase/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.2
+version: 0.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/supabase/README.md
+++ b/charts/supabase/README.md
@@ -191,6 +191,29 @@ autoscaling:
     targetCPUUtilizationPercentage: 80
 ```
 
+### ServiceMonitor
+
+ServiceMonitor creation is disabled by default. It requires the [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator) CRDs (`monitoring.coreos.com/v1`) to be installed in the cluster. To scrape a component, set `serviceMonitor.enabled=true` and enable the component under `serviceMonitor.components.<component>`. A ServiceMonitor is created only for components that are both deployed and enabled here.
+
+Components that natively expose Prometheus metrics on their HTTP port (for example `realtime` and `storage`) work out of the box. Others may require enabling metrics in their own configuration first.
+
+```yaml
+serviceMonitor:
+  enabled: true
+  # Match the label your Prometheus uses to discover ServiceMonitors.
+  labels:
+    release: kube-prometheus-stack
+  interval: 30s
+  components:
+    realtime:
+      enabled: true
+    storage:
+      enabled: true
+      # Per-component overrides of any top-level default.
+      path: /metrics
+      interval: 15s
+```
+
 ### S3 secret
 
 Supabase storage supports the use of S3 object-storage. To enable S3 for Supabase storage:

--- a/charts/supabase/templates/analytics/service.yaml
+++ b/charts/supabase/templates/analytics/service.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "supabase.analytics.fullname" . }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+    app.kubernetes.io/component: analytics
 spec:
   type: {{ .Values.service.analytics.type }}
   ports:

--- a/charts/supabase/templates/auth/service.yaml
+++ b/charts/supabase/templates/auth/service.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "supabase.auth.fullname" . }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+    app.kubernetes.io/component: auth
 spec:
   type: {{ .Values.service.auth.type }}
   ports:

--- a/charts/supabase/templates/db/service.yaml
+++ b/charts/supabase/templates/db/service.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "supabase.db.fullname" . }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+    app.kubernetes.io/component: db
 spec:
   type: {{ .Values.service.db.type }}
   ports:

--- a/charts/supabase/templates/functions/service.yaml
+++ b/charts/supabase/templates/functions/service.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "supabase.functions.fullname" . }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+    app.kubernetes.io/component: functions
 spec:
   type: {{ .Values.service.functions.type }}
   ports:

--- a/charts/supabase/templates/imgproxy/service.yaml
+++ b/charts/supabase/templates/imgproxy/service.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "supabase.imgproxy.fullname" . }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+    app.kubernetes.io/component: imgproxy
 spec:
   type: {{ .Values.service.imgproxy.type }}
   ports:

--- a/charts/supabase/templates/kong/service.yaml
+++ b/charts/supabase/templates/kong/service.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "supabase.kong.fullname" . }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+    app.kubernetes.io/component: kong
 spec:
   type: {{ .Values.service.kong.type }}
   ports:

--- a/charts/supabase/templates/meta/service.yaml
+++ b/charts/supabase/templates/meta/service.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "supabase.meta.fullname" . }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+    app.kubernetes.io/component: meta
 spec:
   type: {{ .Values.service.meta.type }}
   ports:

--- a/charts/supabase/templates/minio/service.yaml
+++ b/charts/supabase/templates/minio/service.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "supabase.minio.fullname" . }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+    app.kubernetes.io/component: minio
 spec:
   type: {{ .Values.service.minio.type }}
   ports:

--- a/charts/supabase/templates/realtime/service.yaml
+++ b/charts/supabase/templates/realtime/service.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "supabase.realtime.fullname" . }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+    app.kubernetes.io/component: realtime
 spec:
   type: {{ .Values.service.realtime.type }}
   ports:

--- a/charts/supabase/templates/rest/service.yaml
+++ b/charts/supabase/templates/rest/service.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "supabase.rest.fullname" . }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rest
 spec:
   type: {{ .Values.service.rest.type }}
   ports:

--- a/charts/supabase/templates/servicemonitor.yaml
+++ b/charts/supabase/templates/servicemonitor.yaml
@@ -1,0 +1,52 @@
+{{- if .Values.serviceMonitor.enabled -}}
+{{- $root := . -}}
+{{- $sm := .Values.serviceMonitor -}}
+{{- range $component, $config := $sm.components -}}
+{{- if and $config.enabled (index $root.Values.deployment $component "enabled") }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include (printf "supabase.%s.fullname" $component) $root }}
+  {{- with $sm.namespace }}
+  namespace: {{ . }}
+  {{- end }}
+  labels:
+    {{- include "supabase.labels" $root | nindent 4 }}
+    app.kubernetes.io/component: {{ $component }}
+    {{- with $sm.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with $sm.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ $root.Release.Namespace }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ $root.Release.Name }}
+      app.kubernetes.io/component: {{ $component }}
+  endpoints:
+    - port: {{ $config.port | default $sm.port }}
+      path: {{ $config.path | default $sm.path }}
+      scheme: {{ $config.scheme | default $sm.scheme }}
+      interval: {{ $config.interval | default $sm.interval }}
+      scrapeTimeout: {{ $config.scrapeTimeout | default $sm.scrapeTimeout }}
+      {{- with (or $config.tlsConfig $sm.tlsConfig) }}
+      tlsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (or $config.relabelings $sm.relabelings) }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (or $config.metricRelabelings $sm.metricRelabelings) }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/supabase/templates/storage/service.yaml
+++ b/charts/supabase/templates/storage/service.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "supabase.storage.fullname" . }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+    app.kubernetes.io/component: storage
 spec:
   type: {{ .Values.service.storage.type }}
   ports:

--- a/charts/supabase/templates/studio/service.yaml
+++ b/charts/supabase/templates/studio/service.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "supabase.studio.fullname" . }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+    app.kubernetes.io/component: studio
 spec:
   type: {{ .Values.service.studio.type }}
   ports:

--- a/charts/supabase/templates/vector/service.yaml
+++ b/charts/supabase/templates/vector/service.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "supabase.vector.fullname" . }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+    app.kubernetes.io/component: vector
 spec:
   type: {{ .Values.service.vector.type }}
   ports:

--- a/charts/supabase/values.yaml
+++ b/charts/supabase/values.yaml
@@ -1115,6 +1115,67 @@ service:
     labels: {}
     portName: http
 
+# Prometheus Operator ServiceMonitor resources for scraping component metrics.
+# Requires the Prometheus Operator CRDs (monitoring.coreos.com/v1) to be installed in the cluster.
+serviceMonitor:
+  # Master switch. When false, no ServiceMonitor is created regardless of the per-component settings below.
+  enabled: false
+  # Namespace to create the ServiceMonitor resources in. Defaults to the release namespace when empty.
+  namespace: ""
+  # Extra labels added to every ServiceMonitor (e.g. to match your Prometheus `serviceMonitorSelector`).
+  labels: {}
+  # Extra annotations added to every ServiceMonitor.
+  annotations: {}
+  # Default scrape interval. Overridable per component.
+  interval: 30s
+  # Default scrape timeout. Overridable per component.
+  scrapeTimeout: 10s
+  # Default Service port name to scrape. The chart Services expose the "http" port. Overridable per component.
+  port: http
+  # Default metrics path. Overridable per component.
+  path: /metrics
+  # Default scheme, http or https. Overridable per component.
+  scheme: http
+  # Default TLS configuration for the endpoint. Overridable per component.
+  tlsConfig: {}
+  # Default relabelings applied before scraping. Overridable per component.
+  relabelings: []
+  # Default metric relabelings applied after scraping. Overridable per component.
+  metricRelabelings: []
+  # Per-component configuration. A ServiceMonitor is created only for a component that is deployed
+  # (`deployment.<component>.enabled`) AND has `enabled: true` here. Any default above (interval,
+  # scrapeTimeout, port, path, scheme, tlsConfig, relabelings, metricRelabelings) can be overridden
+  # inside a component block. Components that natively expose Prometheus metrics on their HTTP port
+  # (e.g. realtime, storage) work out of the box; others may require enabling metrics in their own
+  # configuration first.
+  components:
+    analytics:
+      enabled: false
+    auth:
+      enabled: false
+    db:
+      enabled: false
+    functions:
+      enabled: false
+    imgproxy:
+      enabled: false
+    kong:
+      enabled: false
+    meta:
+      enabled: false
+    minio:
+      enabled: false
+    realtime:
+      enabled: false
+    rest:
+      enabled: false
+    storage:
+      enabled: false
+    studio:
+      enabled: false
+    vector:
+      enabled: false
+
 autoscaling:
   analytics:
     enabled: false


### PR DESCRIPTION
Adds opt-in Prometheus Operator ServiceMonitor support to the supabase chart, addressing #137.

A top-level `serviceMonitor` block gates creation behind a master switch plus a per-component toggle. A ServiceMonitor is created only for a component that is both deployed (`deployment.<component>.enabled`) and enabled under `serviceMonitor.components.<component>`. Global defaults (interval, scrapeTimeout, port, path, scheme, tlsConfig, relabelings, metricRelabelings) can be overridden per component. Everything defaults to off, so the rendered output is unchanged unless a user opts in, and no Prometheus Operator CRD is required for the default install.

To let each ServiceMonitor select a single component's Service, the recommended `app.kubernetes.io/component` label is added to every component Service. This is additive and does not change any existing selector.

Chart version bumped 0.7.2 -> 0.8.0 (minor, new feature).

Validation (local):
- `helm lint` and `ct lint` pass
- `helm template` with default values renders 0 ServiceMonitor
- `helm template` with `serviceMonitor.enabled` plus per-component toggles renders one ServiceMonitor per enabled and deployed component, with per-component overrides applied
- a component whose deployment is disabled renders no ServiceMonitor
- `ct install` was not run locally (it needs a kind cluster). Because the feature defaults to off, the installed resources are unchanged apart from the additive Service label.

related: #137
