### PR TITLE
feat: inherit Postgres image from referenced database for migration and project sync Jobs

### DIFF
--- a/api/v1alpha1/common_types.go
+++ b/api/v1alpha1/common_types.go
@@ -92,6 +92,11 @@ type ResolvedDatabase struct {
 	// PasswordRef references the secret containing the database password
 	// +kubebuilder:validation:Required
 	PasswordRef SecretKeyRef `json:"passwordRef"`
+
+	// Image is the Postgres image the database runs, so dependent workloads
+	// (such as migrations) can match the database version.
+	// +optional
+	Image string `json:"image,omitempty"`
 }
 
 // ServiceSpec defines the configuration for a component Service.

--- a/config/crd/bases/core.supabase.io_singledatabases.yaml
+++ b/config/crd/bases/core.supabase.io_singledatabases.yaml
@@ -1452,6 +1452,11 @@ spec:
                   host:
                     description: Host defines the database host
                     type: string
+                  image:
+                    description: |-
+                      Image is the Postgres image the database runs, so dependent workloads
+                      (such as migrations) can match the database version.
+                    type: string
                   passwordRef:
                     description: PasswordRef references the secret containing the
                       database password

--- a/internal/controller/migration_test.go
+++ b/internal/controller/migration_test.go
@@ -30,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/utils/ptr"
 
 	supabasev1alpha1 "github.com/supabase-community/supabase-kubernetes/api/v1alpha1"
 	migrationpkg "github.com/supabase-community/supabase-kubernetes/internal/migration"
@@ -56,7 +57,7 @@ var _ = Describe("Migration Controller", func() {
 	// Ready by repeatedly marking its StatefulSet status as ready. The
 	// SingleDatabase reconciler then writes ResolvedDatabase and Ready=True
 	// itself, which is a stable steady state that database.ResolveRef can read.
-	driveSingleDatabaseReady := func(name string) *supabasev1alpha1.SingleDatabase {
+	driveSingleDatabaseReady := func(name, image string) *supabasev1alpha1.SingleDatabase {
 		db := &supabasev1alpha1.SingleDatabase{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
@@ -68,6 +69,9 @@ var _ = Describe("Migration Controller", func() {
 					Size:        resource.MustParse("1Gi"),
 				},
 			},
+		}
+		if image != "" {
+			db.Spec.Image = &image
 		}
 		Expect(k8sClient.Create(ctx, db)).To(Succeed())
 
@@ -122,7 +126,7 @@ var _ = Describe("Migration Controller", func() {
 
 	Context("when a Migration is created against a ready database", func() {
 		It("creates a ConfigMap and a Job wired to the resolved database", func() {
-			db := driveSingleDatabaseReady("pg")
+			db := driveSingleDatabaseReady("pg", "")
 			m := newMigration("mig", "pg")
 			Expect(k8sClient.Create(ctx, m)).To(Succeed())
 
@@ -141,6 +145,10 @@ var _ = Describe("Migration Controller", func() {
 				g.Expect(job.OwnerReferences).To(HaveLen(1))
 				g.Expect(job.OwnerReferences[0].Kind).To(Equal("Migration"))
 				g.Expect(job.Spec.Template.Spec.Containers).To(HaveLen(1))
+
+				// With no explicit override, the Job inherits the resolved
+				// database image (here the default Postgres image).
+				g.Expect(job.Spec.Template.Spec.Containers[0].Image).To(Equal(db.Status.ResolvedDatabase.Image))
 
 				envMap := map[string]string{}
 				for _, e := range job.Spec.Template.Spec.Containers[0].Env {
@@ -166,8 +174,36 @@ var _ = Describe("Migration Controller", func() {
 			}, defaultTimeout, defaultPolling).Should(Succeed())
 		})
 
+		It("inherits a custom database image, and an explicit spec image wins", func() {
+			const dbImage = "example.com/supabase/postgres:custom"
+			const overrideImage = "example.com/supabase/postgres:override"
+
+			driveSingleDatabaseReady("pg", dbImage)
+
+			By("inheriting the resolved database image when the Migration has none")
+			m := newMigration("mig", "pg")
+			Expect(k8sClient.Create(ctx, m)).To(Succeed())
+			jobKey := types.NamespacedName{Name: migrationpkg.MigrationJobName(m), Namespace: ns}
+			Eventually(func(g Gomega) {
+				job := &batchv1.Job{}
+				g.Expect(k8sClient.Get(ctx, jobKey, job)).To(Succeed())
+				g.Expect(job.Spec.Template.Spec.Containers[0].Image).To(Equal(dbImage))
+			}, defaultTimeout, defaultPolling).Should(Succeed())
+
+			By("preferring an explicit spec image over the inherited one")
+			mo := newMigration("mig-override", "pg")
+			mo.Spec.Image = ptr.To(overrideImage)
+			Expect(k8sClient.Create(ctx, mo)).To(Succeed())
+			jobKeyO := types.NamespacedName{Name: migrationpkg.MigrationJobName(mo), Namespace: ns}
+			Eventually(func(g Gomega) {
+				job := &batchv1.Job{}
+				g.Expect(k8sClient.Get(ctx, jobKeyO, job)).To(Succeed())
+				g.Expect(job.Spec.Template.Spec.Containers[0].Image).To(Equal(overrideImage))
+			}, defaultTimeout, defaultPolling).Should(Succeed())
+		})
+
 		It("stays Ready=False with reason JobInProgress until the Job succeeds", func() {
-			driveSingleDatabaseReady("pg")
+			driveSingleDatabaseReady("pg", "")
 			m := newMigration("mig", "pg")
 			Expect(k8sClient.Create(ctx, m)).To(Succeed())
 
@@ -182,7 +218,7 @@ var _ = Describe("Migration Controller", func() {
 		})
 
 		It("becomes Ready=True with AppliedHash set when the Job succeeds", func() {
-			driveSingleDatabaseReady("pg")
+			driveSingleDatabaseReady("pg", "")
 			m := newMigration("mig", "pg")
 			Expect(k8sClient.Create(ctx, m)).To(Succeed())
 
@@ -208,7 +244,7 @@ var _ = Describe("Migration Controller", func() {
 		})
 
 		It("reports Ready=False with reason JobFailed when the Job fails", func() {
-			driveSingleDatabaseReady("pg")
+			driveSingleDatabaseReady("pg", "")
 			m := newMigration("mig", "pg")
 			Expect(k8sClient.Create(ctx, m)).To(Succeed())
 

--- a/internal/controller/project_test.go
+++ b/internal/controller/project_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Project Controller", func() {
 	// Ready by marking its StatefulSet status as ready. The SingleDatabase
 	// reconciler then writes Ready=True and populates ResolvedDatabase, which
 	// is a stable steady state that the Project reconciler can rely on.
-	driveSingleDatabaseReady := func(name string) *supabasev1alpha1.SingleDatabase {
+	driveSingleDatabaseReady := func(name string, image ...string) *supabasev1alpha1.SingleDatabase {
 		db := &supabasev1alpha1.SingleDatabase{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
@@ -69,6 +69,9 @@ var _ = Describe("Project Controller", func() {
 					Size:        resource.MustParse("1Gi"),
 				},
 			},
+		}
+		if len(image) > 0 && image[0] != "" {
+			db.Spec.Image = &image[0]
 		}
 		Expect(k8sClient.Create(ctx, db)).To(Succeed())
 
@@ -277,12 +280,26 @@ var _ = Describe("Project Controller", func() {
 		})
 
 		It("creates the sync-jwt and sync-password Jobs and records hashes on success", func() {
-			driveSingleDatabaseReady("pg")
+			db := driveSingleDatabaseReady("pg")
 			proj := newProject("demo", "pg")
 			Expect(k8sClient.Create(ctx, proj)).To(Succeed())
 			driveChildMigrationReady(project.ProjectMigration1Name(proj))
 
+			// With no custom database image, each Job inherits the resolved
+			// database image (here the default Postgres image). sync-password
+			// is only created after sync-jwt succeeds, so assert and advance
+			// them in order.
+			expectJobImage := func(name, image string) {
+				Eventually(func(g Gomega) {
+					job := &batchv1.Job{}
+					g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: ns}, job)).To(Succeed())
+					g.Expect(job.Spec.Template.Spec.Containers[0].Image).To(Equal(image))
+				}, defaultTimeout, defaultPolling).Should(Succeed())
+			}
+
+			expectJobImage(project.SyncJWTJobName(proj), db.Status.ResolvedDatabase.Image)
 			markJobSucceeded(project.SyncJWTJobName(proj))
+			expectJobImage(project.SyncPasswordJobName(proj), db.Status.ResolvedDatabase.Image)
 			markJobSucceeded(project.SyncPasswordJobName(proj))
 
 			Eventually(func(g Gomega) {
@@ -291,6 +308,27 @@ var _ = Describe("Project Controller", func() {
 				g.Expect(got.Status.JwtSyncHash).NotTo(BeEmpty())
 				g.Expect(got.Status.PasswordSyncHash).NotTo(BeEmpty())
 			}, defaultTimeout, defaultPolling).Should(Succeed())
+		})
+
+		It("sync Jobs inherit a custom database image", func() {
+			const dbImage = "example.com/supabase/postgres:custom"
+			driveSingleDatabaseReady("pg", dbImage)
+			proj := newProject("demo", "pg")
+			Expect(k8sClient.Create(ctx, proj)).To(Succeed())
+			driveChildMigrationReady(project.ProjectMigration1Name(proj))
+
+			expectJobImage := func(name string) {
+				Eventually(func(g Gomega) {
+					job := &batchv1.Job{}
+					g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: ns}, job)).To(Succeed())
+					g.Expect(job.Spec.Template.Spec.Containers[0].Image).To(Equal(dbImage))
+				}, defaultTimeout, defaultPolling).Should(Succeed())
+			}
+
+			// sync-password is created only after sync-jwt succeeds.
+			expectJobImage(project.SyncJWTJobName(proj))
+			markJobSucceeded(project.SyncJWTJobName(proj))
+			expectJobImage(project.SyncPasswordJobName(proj))
 		})
 	})
 

--- a/internal/controller/singledatabase.go
+++ b/internal/controller/singledatabase.go
@@ -298,6 +298,7 @@ func (r *SingleDatabaseReconciler) markReady(ctx context.Context, db *supabasev1
 			Name: singledatabase.PostgresSecretName(db),
 			Key:  singledatabase.DefaultSecretKeyPassword,
 		},
+		Image: singledatabase.ImageOrDefault(db),
 	}
 
 	reconciler.SetReady(db, "ReconcileSucceeded", "All resources reconciled successfully")

--- a/internal/migration/defaults.go
+++ b/internal/migration/defaults.go
@@ -61,10 +61,14 @@ func MigrationSelectorLabels(migration *supabasev1alpha1.Migration) map[string]s
 	}
 }
 
-// getImageOrDefault returns the Postgres image from the spec or the default image.
-func getImageOrDefault(migration *supabasev1alpha1.Migration) string {
+// getImageOrDefault returns the migration image, preferring an explicit spec
+// override, then the resolved database image, then the default image.
+func getImageOrDefault(migration *supabasev1alpha1.Migration, db *supabasev1alpha1.ResolvedDatabase) string {
 	if migration.Spec.Image != nil && *migration.Spec.Image != "" {
 		return *migration.Spec.Image
+	}
+	if db != nil && db.Image != "" {
+		return db.Image
 	}
 	return DefaultPostgresImage
 }

--- a/internal/migration/migration_job.go
+++ b/internal/migration/migration_job.go
@@ -90,7 +90,7 @@ func podAnnotations(migration *supabasev1alpha1.Migration) map[string]string {
 func buildMigrationContainer(migration *supabasev1alpha1.Migration, db *supabasev1alpha1.ResolvedDatabase) corev1.Container {
 	return corev1.Container{
 		Name:            "migration",
-		Image:           getImageOrDefault(migration),
+		Image:           getImageOrDefault(migration, db),
 		ImagePullPolicy: getImagePullPolicyOrDefault(migration),
 		Command:         []string{"/bin/sh", "-c"},
 		Args:            []string{assets.MigrationApplyScript},

--- a/internal/project/defaults.go
+++ b/internal/project/defaults.go
@@ -118,6 +118,15 @@ const (
 	StorageSecretAccessKeySecret = "accessKeySecret"
 )
 
+// postgresImageOrDefault returns the resolved database image so Postgres-based
+// Jobs match the database version, falling back to the default image.
+func postgresImageOrDefault(db *supabasev1alpha1.ResolvedDatabase) string {
+	if db != nil && db.Image != "" {
+		return db.Image
+	}
+	return DefaultPostgresImage
+}
+
 // ProjectLabels returns the common labels for a Project and its resources.
 func ProjectLabels(project *supabasev1alpha1.Project) map[string]string {
 	return map[string]string{

--- a/internal/project/sync_jwt_job.go
+++ b/internal/project/sync_jwt_job.go
@@ -67,7 +67,7 @@ func SyncJWTJob(project *supabasev1alpha1.Project, db *supabasev1alpha1.Resolved
 func buildSyncJWTContainer(project *supabasev1alpha1.Project, db *supabasev1alpha1.ResolvedDatabase) corev1.Container {
 	return corev1.Container{
 		Name:            "sync-jwt",
-		Image:           DefaultPostgresImage,
+		Image:           postgresImageOrDefault(db),
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Command:         []string{"/bin/sh", "-c"},
 		Args:            []string{assets.ProjectSyncJWTScript},

--- a/internal/project/sync_password_job.go
+++ b/internal/project/sync_password_job.go
@@ -67,7 +67,7 @@ func SyncPasswordJob(project *supabasev1alpha1.Project, db *supabasev1alpha1.Res
 func buildSyncPasswordContainer(db *supabasev1alpha1.ResolvedDatabase) corev1.Container {
 	return corev1.Container{
 		Name:            "sync-password",
-		Image:           DefaultPostgresImage,
+		Image:           postgresImageOrDefault(db),
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Command:         []string{"/bin/sh", "-c"},
 		Args:            []string{assets.ProjectSyncPasswordScript},

--- a/internal/singledatabase/postgres_statefulset.go
+++ b/internal/singledatabase/postgres_statefulset.go
@@ -102,7 +102,7 @@ func podAnnotations(db *supabasev1alpha1.SingleDatabase, secretHash string) map[
 func buildPostgresContainer(db *supabasev1alpha1.SingleDatabase) corev1.Container {
 	return corev1.Container{
 		Name:            "postgres",
-		Image:           getImageOrDefault(db),
+		Image:           ImageOrDefault(db),
 		ImagePullPolicy: getImagePullPolicyOrDefault(db),
 		Args: []string{
 			"-c", "config_file=/etc/postgresql/postgresql.conf",
@@ -123,7 +123,7 @@ func buildPostgresContainer(db *supabasev1alpha1.SingleDatabase) corev1.Containe
 func buildPasswordSyncInitContainer(db *supabasev1alpha1.SingleDatabase) corev1.Container {
 	return corev1.Container{
 		Name:            "password-sync",
-		Image:           getImageOrDefault(db),
+		Image:           ImageOrDefault(db),
 		ImagePullPolicy: getImagePullPolicyOrDefault(db),
 		Command:         []string{"/bin/sh", "-c"},
 		Args:            []string{assets.SingleDatabasePasswordSyncScript},
@@ -136,7 +136,7 @@ func buildPasswordSyncInitContainer(db *supabasev1alpha1.SingleDatabase) corev1.
 func buildPgsodiumInitContainer(db *supabasev1alpha1.SingleDatabase) corev1.Container {
 	return corev1.Container{
 		Name:            "init-pgsodium",
-		Image:           getImageOrDefault(db),
+		Image:           ImageOrDefault(db),
 		ImagePullPolicy: getImagePullPolicyOrDefault(db),
 		Command:         []string{"/bin/sh", "-c"},
 		Args:            []string{assets.SingleDatabasePgsodiumInitScript},
@@ -192,8 +192,8 @@ func postgresLifecycle() *corev1.Lifecycle {
 	}
 }
 
-// getImageOrDefault returns the Postgres image from the spec or the default image.
-func getImageOrDefault(db *supabasev1alpha1.SingleDatabase) string {
+// ImageOrDefault returns the Postgres image from the spec or the default image.
+func ImageOrDefault(db *supabasev1alpha1.SingleDatabase) string {
 	if db.Spec.Image != nil && *db.Spec.Image != "" {
 		return *db.Spec.Image
 	}


### PR DESCRIPTION
## What

The operator runs several **Postgres-image Jobs** against a referenced database — the Migration apply Job, and the Project-generated `sync-jwt` / `sync-password` Jobs. All of them execute SQL against the database, so they should run the **same Postgres image as the database itself** rather than a hardcoded default.

This PR makes all of them inherit the referenced database's image, with **no new field added to the Project spec**. It supersedes #215 (migration only) by folding that change and the Project sync-Job change into a single series.

Image precedence:
1. explicit `spec.image` override (Migration only — highest priority)
2. the resolved database's image (inherited)
3. `DefaultPostgresImage` constant (fallback)

## How

- `ResolvedDatabase` gains an optional `Image` field (`api/v1alpha1/common_types.go`).
- The SingleDatabase controller populates it in `markReady` via the exported `singledatabase.ImageOrDefault(db)` helper.
- **Migration** Job builder falls back to `db.Image` before the default constant (`internal/migration/defaults.go`, `migration_job.go`).
- **Project** `sync-jwt` and `sync-password` Job builders resolve the image via a new `postgresImageOrDefault(db)` helper (`internal/project/defaults.go`, `sync_jwt_job.go`, `sync_password_job.go`).
- CRD regenerated (`resolvedDatabase.image` added to SingleDatabase status).

## Behavioral impact

Since the migration/singledatabase/project default constants are currently identical (`supabase/postgres:17.6.1.084`), behavior only changes when the database uses a **custom image**. An explicit Migration `spec.image` still wins.

## Tests

- Migration envtest suite: asserts the Job inherits the resolved DB image, and that an explicit `spec.image` overrides it.
- Project envtest suite: asserts both `sync-jwt` and `sync-password` Jobs inherit the resolved DB image, in both the default and custom-image cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)