### PR TITLE
Feat/bump up versions

### DIFF
--- a/charts/supabase/Chart.yaml
+++ b/charts/supabase/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.6.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/supabase/templates/realtime/deployment.yaml
+++ b/charts/supabase/templates/realtime/deployment.yaml
@@ -106,6 +106,11 @@ spec:
                 secretKeyRef:
                   name: {{ include "supabase.secret.jwt.name" . }}
                   key: {{ include "supabase.secret.jwt.key.secret" . }}
+            - name: METRICS_JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "supabase.secret.jwt.name" . }}
+                  key: {{ include "supabase.secret.jwt.key.secret" . }}
             - name: API_JWT_SECRET
               valueFrom:
                 secretKeyRef:

--- a/charts/supabase/values.yaml
+++ b/charts/supabase/values.yaml
@@ -547,13 +547,13 @@ image:
   analytics:
     repository: supabase/logflare
     pullPolicy: IfNotPresent
-    tag: "1.36.1"
+    tag: "1.43.1"
     pullSecrets: []
 
   auth:
     repository: supabase/gotrue
     pullPolicy: IfNotPresent
-    tag: "v2.186.0"
+    tag: "v2.189.0"
     pullSecrets: []
 
   db:
@@ -565,7 +565,7 @@ image:
   functions:
     repository: supabase/edge-runtime
     pullPolicy: IfNotPresent
-    tag: "v1.71.2"
+    tag: "v1.74.0"
     pullSecrets: []
 
   imgproxy:
@@ -583,7 +583,7 @@ image:
   meta:
     repository: supabase/postgres-meta
     pullPolicy: IfNotPresent
-    tag: "v0.96.3"
+    tag: "v0.96.6"
     pullSecrets: []
 
   minio:
@@ -595,25 +595,25 @@ image:
   realtime:
     repository: supabase/realtime
     pullPolicy: IfNotPresent
-    tag: "v2.76.5"
+    tag: "v2.102.3"
     pullSecrets: []
 
   rest:
     repository: postgrest/postgrest
     pullPolicy: IfNotPresent
-    tag: "v14.8"
+    tag: "v14.12"
     pullSecrets: []
 
   storage:
     repository: supabase/storage-api
     pullPolicy: IfNotPresent
-    tag: "v1.48.26"
+    tag: "v1.60.4"
     pullSecrets: []
 
   studio:
     repository: supabase/studio
     pullPolicy: IfNotPresent
-    tag: "2026.04.27-sha-5f60601"
+    tag: "2026.06.03-sha-0bca601"
     pullSecrets: []
 
   vector:


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Feature: adds `METRICS_JWT_SECRET` environment variable to the Realtime deployment
- Chore: bumps Supabase service image tags to newer versions

## What is the current behavior?

- Realtime deployment does not expose `METRICS_JWT_SECRET`, which may be required for metrics authentication in newer Realtime versions
- Several Supabase service images are pinned to older releases

## What is the new behavior?

- Adds `METRICS_JWT_SECRET` to `templates/realtime/deployment.yaml`, sourced from the existing JWT secret
- Bumps image tags in `values.yaml`:
  - analytics: `1.36.1` → `1.43.1`
  - auth: `v2.186.0` → `v2.189.0`
  - functions: `v1.71.2` → `v1.74.0`
  - meta: `v0.96.3` → `v0.96.6`
  - realtime: `v2.76.5` → `v2.102.3`
  - rest: `v14.8` → `v14.12`
  - storage: `v1.48.26` → `v1.60.4`
  - studio: `2026.04.27-sha-5f60601` → `2026.06.03-sha-0bca601`