### PR TITLE
fix(helm): inject POSTGRES_HOST and POSTGRES_PORT into Studio for external databases

### DIFF
--- a/charts/supabase/Chart.yaml
+++ b/charts/supabase/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.1
+version: 0.6.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/supabase/templates/studio/deployment.yaml
+++ b/charts/supabase/templates/studio/deployment.yaml
@@ -65,8 +65,10 @@ spec:
               protocol: TCP
           env:
             {{- range $key, $value := .Values.environment.studio }}
+            {{- if and (ne $key "POSTGRES_HOST") (ne $key "POSTGRES_PORT") }}
             - name: {{ $key }}
               value: {{ $value | quote }}
+            {{- end }}
             {{- end }}
             {{- if .Values.deployment.kong.enabled }}
             - name: SUPABASE_URL
@@ -77,10 +79,8 @@ spec:
               value: http://{{ include "supabase.meta.fullname" . }}:{{ .Values.service.meta.port }}
             {{- end }}
 
-            {{- if and .Values.deployment.db.enabled (not (hasKey (default (dict) .Values.environment.studio) "POSTGRES_HOST")) }}
-            - name: POSTGRES_HOST
-              value: {{ include "supabase.db.fullname" . }}
-            {{- end }}
+            {{- include "supabase.db.hostEnv" (dict "root" . "name" "POSTGRES_HOST") | nindent 12 }}
+            {{- include "supabase.db.portEnv" (dict "root" . "name" "POSTGRES_PORT") | nindent 12 }}
 
             {{- if not (hasKey (default (dict) .Values.environment.studio) "POSTGRES_DB") }}
             - name: POSTGRES_DB

--- a/hack/postgres.yaml
+++ b/hack/postgres.yaml
@@ -1,0 +1,500 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: postgres
+
+---
+# PostgreSQL credentials (opaque secret)
+apiVersion: v1
+kind: Secret
+metadata:
+  name: supabase-postgres-auth
+  namespace: postgres
+  labels:
+    app.kubernetes.io/name: postgres
+    app.kubernetes.io/component: database
+    app.kubernetes.io/instance: supabase
+type: Opaque
+data:
+  # Generated random password (base64 encoded).
+  # Decode with: kubectl get secret supabase-postgres-auth -n default -o jsonpath='{.data.password}' | base64 -d
+  password: bU41SFpyVGVQSWljM09MU3F5QzJMdkw3cnQycVBzdER3QU1TeTZVc0lXVT0=
+
+---
+# PostgreSQL data volume
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: supabase-postgres-data
+  namespace: postgres
+  labels:
+    app.kubernetes.io/name: postgres
+    app.kubernetes.io/component: database
+    app.kubernetes.io/instance: supabase
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+
+---
+# Scripts and initdb SQL files used by the Postgres StatefulSet
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: supabase-postgres-scripts
+  namespace: postgres
+  labels:
+    app.kubernetes.io/name: postgres
+    app.kubernetes.io/component: database
+    app.kubernetes.io/instance: supabase
+data:
+  pgsodium-init.sh: |
+    #!/bin/sh
+    set -e
+
+    PGSODIUM_DIR="/mnt/pgsodium"
+
+    # If the pgsodium directory is empty, copy the default
+    # /etc/postgresql-custom files from the image into the PVC
+    if [ -z "$(ls -A "$PGSODIUM_DIR" 2>/dev/null)" ]; then
+      echo "pgsodium volume is empty, copying default /etc/postgresql-custom files..."
+      cp -a /etc/postgresql-custom/. "$PGSODIUM_DIR/"
+    else
+      echo "pgsodium volume already initialized, skipping copy"
+    fi
+  password-sync.sh: |
+    #!/bin/sh
+    set -e
+
+    PGDATA="/var/lib/postgresql/data"
+
+    # Fresh install: no data directory yet, skip password sync
+    if [ ! -f "$PGDATA/PG_VERSION" ]; then
+      echo "Fresh install detected, skipping password sync"
+      exit 0
+    fi
+
+    echo "Existing database detected, syncing passwords..."
+
+    # postgres --single does not support psql's -v variable binding,
+    # so we escape single quotes in the password (doubling them) to
+    # prevent SQL injection if the value ever contains a single quote.
+    ESCAPED_PGPASSWORD=$(printf '%s' "$PGPASSWORD" | sed "s/'/''/g")
+
+    gosu postgres postgres --single -D "$PGDATA" postgres <<SQL
+    ALTER ROLE postgres WITH PASSWORD '${ESCAPED_PGPASSWORD}';
+    ALTER ROLE supabase_admin WITH PASSWORD '${ESCAPED_PGPASSWORD}';
+    SQL
+
+    echo "Password sync completed"
+  init-db.sh: |
+    #!/bin/sh
+    set -e
+
+    echo "Copying init scripts into initdb directory..."
+    cp -r /docker-entrypoint-initdb.d/* /initdb.d/ || true
+    cp /custom-init-scripts/* /initdb.d/migrations/
+    echo "Initialization scripts are ready"
+  97-_supabase.sql: |
+    \set pguser `echo "$POSTGRES_USER"`
+
+    CREATE DATABASE _supabase WITH OWNER :pguser;
+  98-webhooks.sql: |
+    BEGIN;
+      -- Create pg_net extension
+      CREATE EXTENSION IF NOT EXISTS pg_net SCHEMA extensions;
+      -- Create supabase_functions schema
+      CREATE SCHEMA supabase_functions AUTHORIZATION supabase_admin;
+      GRANT USAGE ON SCHEMA supabase_functions TO postgres, anon, authenticated, service_role;
+      ALTER DEFAULT PRIVILEGES IN SCHEMA supabase_functions GRANT ALL ON TABLES TO postgres, anon, authenticated, service_role;
+      ALTER DEFAULT PRIVILEGES IN SCHEMA supabase_functions GRANT ALL ON FUNCTIONS TO postgres, anon, authenticated, service_role;
+      ALTER DEFAULT PRIVILEGES IN SCHEMA supabase_functions GRANT ALL ON SEQUENCES TO postgres, anon, authenticated, service_role;
+      -- supabase_functions.migrations definition
+      CREATE TABLE supabase_functions.migrations (
+        version text PRIMARY KEY,
+        inserted_at timestamptz NOT NULL DEFAULT NOW()
+      );
+      -- Initial supabase_functions migration
+      INSERT INTO supabase_functions.migrations (version) VALUES ('initial');
+      -- supabase_functions.hooks definition
+      CREATE TABLE supabase_functions.hooks (
+        id bigserial PRIMARY KEY,
+        hook_table_id integer NOT NULL,
+        hook_name text NOT NULL,
+        created_at timestamptz NOT NULL DEFAULT NOW(),
+        request_id bigint
+      );
+      CREATE INDEX supabase_functions_hooks_request_id_idx ON supabase_functions.hooks USING btree (request_id);
+      CREATE INDEX supabase_functions_hooks_h_table_id_h_name_idx ON supabase_functions.hooks USING btree (hook_table_id, hook_name);
+      COMMENT ON TABLE supabase_functions.hooks IS 'Supabase Functions Hooks: Audit trail for triggered hooks.';
+      CREATE FUNCTION supabase_functions.http_request()
+        RETURNS trigger
+        LANGUAGE plpgsql
+        AS $function$
+        DECLARE
+          request_id bigint;
+          payload jsonb;
+          url text := TG_ARGV[0]::text;
+          method text := TG_ARGV[1]::text;
+          headers jsonb DEFAULT '{}'::jsonb;
+          params jsonb DEFAULT '{}'::jsonb;
+          timeout_ms integer DEFAULT 1000;
+        BEGIN
+          IF url IS NULL OR url = 'null' THEN
+            RAISE EXCEPTION 'url argument is missing';
+          END IF;
+
+          IF method IS NULL OR method = 'null' THEN
+            RAISE EXCEPTION 'method argument is missing';
+          END IF;
+
+          IF TG_ARGV[2] IS NULL OR TG_ARGV[2] = 'null' THEN
+            headers = '{"Content-Type": "application/json"}'::jsonb;
+          ELSE
+            headers = TG_ARGV[2]::jsonb;
+          END IF;
+
+          IF TG_ARGV[3] IS NULL OR TG_ARGV[3] = 'null' THEN
+            params = '{}'::jsonb;
+          ELSE
+            params = TG_ARGV[3]::jsonb;
+          END IF;
+
+          IF TG_ARGV[4] IS NULL OR TG_ARGV[4] = 'null' THEN
+            timeout_ms = 1000;
+          ELSE
+            timeout_ms = TG_ARGV[4]::integer;
+          END IF;
+
+          CASE
+            WHEN method = 'GET' THEN
+              SELECT http_get INTO request_id FROM net.http_get(
+                url,
+                params,
+                headers,
+                timeout_ms
+              );
+            WHEN method = 'POST' THEN
+              payload = jsonb_build_object(
+                'old_record', OLD,
+                'record', NEW,
+                'type', TG_OP,
+                'table', TG_TABLE_NAME,
+                'schema', TG_TABLE_SCHEMA
+              );
+
+              SELECT http_post INTO request_id FROM net.http_post(
+                url,
+                payload,
+                params,
+                headers,
+                timeout_ms
+              );
+            ELSE
+              RAISE EXCEPTION 'method argument % is invalid', method;
+          END CASE;
+
+          INSERT INTO supabase_functions.hooks
+            (hook_table_id, hook_name, request_id)
+          VALUES
+            (TG_RELID, TG_NAME, request_id);
+
+          RETURN NEW;
+        END
+      $function$;
+      -- Supabase super admin
+      DO
+      $$
+      BEGIN
+        IF NOT EXISTS (
+          SELECT 1
+          FROM pg_roles
+          WHERE rolname = 'supabase_functions_admin'
+        )
+        THEN
+          CREATE USER supabase_functions_admin NOINHERIT CREATEROLE LOGIN NOREPLICATION;
+        END IF;
+      END
+      $$;
+      GRANT ALL PRIVILEGES ON SCHEMA supabase_functions TO supabase_functions_admin;
+      GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA supabase_functions TO supabase_functions_admin;
+      GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA supabase_functions TO supabase_functions_admin;
+      ALTER USER supabase_functions_admin SET search_path = "supabase_functions";
+      ALTER table "supabase_functions".migrations OWNER TO supabase_functions_admin;
+      ALTER table "supabase_functions".hooks OWNER TO supabase_functions_admin;
+      ALTER function "supabase_functions".http_request() OWNER TO supabase_functions_admin;
+      GRANT supabase_functions_admin TO postgres;
+      -- Remove unused supabase_pg_net_admin role
+      DO
+      $$
+      BEGIN
+        IF EXISTS (
+          SELECT 1
+          FROM pg_roles
+          WHERE rolname = 'supabase_pg_net_admin'
+        )
+        THEN
+          REASSIGN OWNED BY supabase_pg_net_admin TO supabase_admin;
+          DROP OWNED BY supabase_pg_net_admin;
+          DROP ROLE supabase_pg_net_admin;
+        END IF;
+      END
+      $$;
+      -- pg_net grants when extension is already enabled
+      DO
+      $$
+      BEGIN
+        IF EXISTS (
+          SELECT 1
+          FROM pg_extension
+          WHERE extname = 'pg_net'
+        )
+        THEN
+          GRANT USAGE ON SCHEMA net TO supabase_functions_admin, postgres, anon, authenticated, service_role;
+          ALTER function net.http_get(url text, params jsonb, headers jsonb, timeout_milliseconds integer) SECURITY DEFINER;
+          ALTER function net.http_post(url text, body jsonb, params jsonb, headers jsonb, timeout_milliseconds integer) SECURITY DEFINER;
+          ALTER function net.http_get(url text, params jsonb, headers jsonb, timeout_milliseconds integer) SET search_path = net;
+          ALTER function net.http_post(url text, body jsonb, params jsonb, headers jsonb, timeout_milliseconds integer) SET search_path = net;
+          REVOKE ALL ON FUNCTION net.http_get(url text, params jsonb, headers jsonb, timeout_milliseconds integer) FROM PUBLIC;
+          REVOKE ALL ON FUNCTION net.http_post(url text, body jsonb, params jsonb, headers jsonb, timeout_milliseconds integer) FROM PUBLIC;
+          GRANT EXECUTE ON FUNCTION net.http_get(url text, params jsonb, headers jsonb, timeout_milliseconds integer) TO supabase_functions_admin, postgres, anon, authenticated, service_role;
+          GRANT EXECUTE ON FUNCTION net.http_post(url text, body jsonb, params jsonb, headers jsonb, timeout_milliseconds integer) TO supabase_functions_admin, postgres, anon, authenticated, service_role;
+        END IF;
+      END
+      $$;
+      -- Event trigger for pg_net
+      CREATE OR REPLACE FUNCTION extensions.grant_pg_net_access()
+      RETURNS event_trigger
+      LANGUAGE plpgsql
+      AS $$
+      BEGIN
+        IF EXISTS (
+          SELECT 1
+          FROM pg_event_trigger_ddl_commands() AS ev
+          JOIN pg_extension AS ext
+          ON ev.objid = ext.oid
+          WHERE ext.extname = 'pg_net'
+        )
+        THEN
+          GRANT USAGE ON SCHEMA net TO supabase_functions_admin, postgres, anon, authenticated, service_role;
+          ALTER function net.http_get(url text, params jsonb, headers jsonb, timeout_milliseconds integer) SECURITY DEFINER;
+          ALTER function net.http_post(url text, body jsonb, params jsonb, headers jsonb, timeout_milliseconds integer) SECURITY DEFINER;
+          ALTER function net.http_get(url text, params jsonb, headers jsonb, timeout_milliseconds integer) SET search_path = net;
+          ALTER function net.http_post(url text, body jsonb, params jsonb, headers jsonb, timeout_milliseconds integer) SET search_path = net;
+          REVOKE ALL ON FUNCTION net.http_get(url text, params jsonb, headers jsonb, timeout_milliseconds integer) FROM PUBLIC;
+          REVOKE ALL ON FUNCTION net.http_post(url text, body jsonb, params jsonb, headers jsonb, timeout_milliseconds integer) FROM PUBLIC;
+          GRANT EXECUTE ON FUNCTION net.http_get(url text, params jsonb, headers jsonb, timeout_milliseconds integer) TO supabase_functions_admin, postgres, anon, authenticated, service_role;
+          GRANT EXECUTE ON FUNCTION net.http_post(url text, body jsonb, params jsonb, headers jsonb, timeout_milliseconds integer) TO supabase_functions_admin, postgres, anon, authenticated, service_role;
+        END IF;
+      END;
+      $$;
+      COMMENT ON FUNCTION extensions.grant_pg_net_access IS 'Grants access to pg_net';
+      DO
+      $$
+      BEGIN
+        IF NOT EXISTS (
+          SELECT 1
+          FROM pg_event_trigger
+          WHERE evtname = 'issue_pg_net_access'
+        ) THEN
+          CREATE EVENT TRIGGER issue_pg_net_access ON ddl_command_end WHEN TAG IN ('CREATE EXTENSION')
+          EXECUTE PROCEDURE extensions.grant_pg_net_access();
+        END IF;
+      END
+      $$;
+      INSERT INTO supabase_functions.migrations (version) VALUES ('20210809183423_update_grants');
+      ALTER function supabase_functions.http_request() SECURITY DEFINER;
+      ALTER function supabase_functions.http_request() SET search_path = supabase_functions;
+      REVOKE ALL ON FUNCTION supabase_functions.http_request() FROM PUBLIC;
+      GRANT EXECUTE ON FUNCTION supabase_functions.http_request() TO postgres, anon, authenticated, service_role;
+    COMMIT;
+  99-logs.sql: |
+    \set pguser `echo "$POSTGRES_USER"`
+    \c _supabase
+    create schema if not exists _analytics;
+    alter schema _analytics owner to :pguser;
+    \c postgres
+  99-pooler.sql: |
+    \set pguser `echo "$POSTGRES_USER"`
+
+    \c _supabase
+    create schema if not exists _supavisor;
+    alter schema _supavisor owner to :pguser;
+    \c postgres
+  99-realtime.sql: |
+    \set pguser `echo "$POSTGRES_USER"`
+
+    create schema if not exists _realtime;
+    alter schema _realtime owner to :pguser;
+  99-roles.sql: |
+    -- NOTE: change to your own passwords for production environments
+    \set pgpass `echo "$POSTGRES_PASSWORD"`
+
+    ALTER USER authenticator WITH PASSWORD :'pgpass';
+    ALTER USER pgbouncer WITH PASSWORD :'pgpass';
+    ALTER USER supabase_auth_admin WITH PASSWORD :'pgpass';
+    ALTER USER supabase_functions_admin WITH PASSWORD :'pgpass';
+    ALTER USER supabase_storage_admin WITH PASSWORD :'pgpass';
+
+---
+# PostgreSQL Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: supabase-postgres
+  namespace: postgres
+  labels:
+    app.kubernetes.io/name: postgres
+    app.kubernetes.io/component: database
+    app.kubernetes.io/instance: supabase
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: postgres
+    app.kubernetes.io/component: database
+    app.kubernetes.io/instance: supabase
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: 5432
+      protocol: TCP
+
+---
+# PostgreSQL StatefulSet matching the operator reconciliation logic
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: supabase-postgres
+  namespace: postgres
+  labels:
+    app.kubernetes.io/name: postgres
+    app.kubernetes.io/component: database
+    app.kubernetes.io/instance: supabase
+spec:
+  serviceName: supabase-postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: postgres
+      app.kubernetes.io/component: database
+      app.kubernetes.io/instance: supabase
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: postgres
+        app.kubernetes.io/component: database
+        app.kubernetes.io/instance: supabase
+    spec:
+      terminationGracePeriodSeconds: 30
+      initContainers:
+        - name: init-pgsodium
+          image: supabase/postgres:17.6.1.084
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "/scripts/pgsodium-init.sh"]
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /mnt/pgsodium
+              subPath: postgres-custom
+            - name: postgres-scripts
+              mountPath: /scripts
+        - name: init-db
+          image: supabase/postgres:17.6.1.084
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "/custom-init-scripts/init-db.sh"]
+          volumeMounts:
+            - name: initdb-scripts-data
+              mountPath: /initdb.d
+            - name: postgres-scripts
+              mountPath: /custom-init-scripts
+        - name: password-sync
+          image: supabase/postgres:17.6.1.084
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "/scripts/password-sync.sh"]
+          env:
+            - name: POSTGRES_HOST
+              value: /var/run/postgresql
+            - name: PGPORT
+              value: "5432"
+            - name: POSTGRES_PORT
+              value: "5432"
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: supabase-postgres-auth
+                  key: password
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: supabase-postgres-auth
+                  key: password
+            - name: PGDATABASE
+              value: postgres
+            - name: POSTGRES_DB
+              value: postgres
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+              subPath: postgres-data
+            - name: postgres-data
+              mountPath: /etc/postgresql-custom
+              subPath: postgres-custom
+            - name: postgres-scripts
+              mountPath: /scripts
+      containers:
+        - name: postgres
+          image: supabase/postgres:17.6.1.084
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-c"
+            - "config_file=/etc/postgresql/postgresql.conf"
+            - "-c"
+            - "log_min_messages=fatal"
+          env:
+            - name: POSTGRES_HOST
+              value: /var/run/postgresql
+            - name: PGPORT
+              value: "5432"
+            - name: POSTGRES_PORT
+              value: "5432"
+            - name: POSTGRES_USER
+              value: supabase_admin
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: supabase-postgres-auth
+                  key: password
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: supabase-postgres-auth
+                  key: password
+            - name: PGDATABASE
+              value: postgres
+            - name: POSTGRES_DB
+              value: postgres
+          ports:
+            - name: postgres
+              containerPort: 5432
+              protocol: TCP
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+              subPath: postgres-data
+            - name: postgres-data
+              mountPath: /etc/postgresql-custom
+              subPath: postgres-custom
+            - name: initdb-scripts-data
+              mountPath: /docker-entrypoint-initdb.d
+      volumes:
+        - name: postgres-data
+          persistentVolumeClaim:
+            claimName: supabase-postgres-data
+        - name: postgres-scripts
+          configMap:
+            name: supabase-postgres-scripts
+            defaultMode: 0755
+        - name: initdb-scripts-data
+          emptyDir: {}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When using an external PostgreSQL database (`deployment.db.enabled: false`), the Studio deployment does not receive the `POSTGRES_HOST` and `POSTGRES_PORT` environment variables automatically:

- `POSTGRES_HOST` is only injected when the internal database is enabled (`deployment.db.enabled: true`).
- `POSTGRES_PORT` is never injected automatically by the Studio template.

This forces users to manually set both variables under `environment.studio`, even though `secret.db.host` and `secret.db.port` are already configured for other Supabase components.

## What is the new behavior?

The Studio deployment now uses the same shared helpers as the other Supabase components:

- `supabase.db.hostEnv`
- `supabase.db.portEnv`

This ensures that:

- `POSTGRES_HOST` and `POSTGRES_PORT` are always injected.
- When `deployment.db.enabled: false`, the values come from `secret.db.host` and `secret.db.port`.
- When `deployment.db.enabled: true`, the values point to the internal database service.

Values manually provided in `environment.studio` for `POSTGRES_HOST` and `POSTGRES_PORT` are now skipped from the generic env range, matching the behavior of `DB_HOST`/`DB_PORT` in the other deployments.

## Additional context

Closes #208