### PR TITLE
feat(db): add securityContext to init containers

### DIFF
--- a/charts/supabase/templates/db/statefulset.yaml
+++ b/charts/supabase/templates/db/statefulset.yaml
@@ -72,7 +72,9 @@ spec:
           volumeMounts:
             - mountPath: /mnt/pgsodium
               name: pgsodium
-      {{- if .Values.deployment.db.initDb }}
+          securityContext:
+            {{- toYaml .Values.deployment.db.securityContext | nindent 12 }}
+        {{- if .Values.deployment.db.initDb }}
         - name: init-db
           image: "{{ .Values.image.db.repository }}:{{ .Values.image.db.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.db.pullPolicy }}
@@ -100,10 +102,12 @@ spec:
               name: custom-migrations
             - mountPath: /initdb.d
               name: initdb-scripts-data
-      {{- end }}
-      {{- with .Values.deployment.db.extraInitContainers }}
+          securityContext:
+            {{- toYaml .Values.deployment.db.securityContext | nindent 12 }}
+        {{- end }}
+        {{- with .Values.deployment.db.extraInitContainers }}
           {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       containers:
         - name: {{ include "supabase.db.name" $ }}
           image: "{{ .Values.image.db.repository }}:{{ .Values.image.db.tag | default .Chart.AppVersion }}"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Closes #221

The `init-db` and `init-pgsodium` init containers in the `db` StatefulSet do not define a `securityContext`. On clusters enforcing the `PodSecurity "restricted:latest"` policy, this causes warnings or installation failures such as:

would violate PodSecurity "restricted:latest": allowPrivilegeEscalation != false (container "init-db" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "init-db" must set securityContext.capabilities.drop="ALL"), runAsNonRoot != true (pod or container "init-db" must set securityContext.runAsNonRoot=true)

## What is the new behavior?

This PR adds `securityContext` to both `init-pgsodium` and `init-db` init containers, reusing the existing `.Values.deployment.db.securityContext` value:

```yaml
securityContext:
  {{- toYaml .Values.deployment.db.securityContext | nindent 12 }}
Users can now configure security settings via values.yaml:
deployment:
  db:
    securityContext:
      allowPrivilegeEscalation: false
      capabilities:
        drop:
          - ALL
      runAsNonRoot: true
 ```
This value is applied to both the main PostgreSQL container and the init containers, allowing the chart to comply with restricted PodSecurity policies.


Additional context

- helm template renders correctly with both empty and populated securityContext values.
- helm lint passes without errors.