### PR TITLE
fix(minio): align credentials with minio secret

### DIFF
--- a/charts/supabase/templates/minio/deployment.yaml
+++ b/charts/supabase/templates/minio/deployment.yaml
@@ -73,13 +73,8 @@ spec:
             - name: MINIO_ROOT_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  {{- if .Values.secret.s3.secretRef }}
-                  name: {{ include "supabase.secret.s3.name" . }}
-                  key: {{ include "supabase.secret.s3.key.password" . }}
-                  {{- else }}
                   name: {{ include "supabase.secret.minio.name" . }}
                   key: {{ include "supabase.secret.minio.key.password" . }}
-                  {{- end }}
           {{- with .Values.deployment.minio.envFrom }}
           envFrom:
             {{- toYaml . | nindent 12 }}

--- a/charts/supabase/templates/storage/deployment.yaml
+++ b/charts/supabase/templates/storage/deployment.yaml
@@ -78,13 +78,8 @@ spec:
             - name: MINIO_ROOT_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  {{- if .Values.secret.s3.secretRef }}
-                  name: {{ include "supabase.secret.s3.name" . }}
-                  key: {{ include "supabase.secret.s3.key.password" . }}
-                  {{- else }}
                   name: {{ include "supabase.secret.minio.name" . }}
                   key: {{ include "supabase.secret.minio.key.password" . }}
-                  {{- end }}
             - name: GLOBAL_S3_BUCKET
               value: {{ .Values.environment.storage.GLOBAL_S3_BUCKET }}
           imagePullPolicy: {{ .Values.image.minioClient.pullPolicy }}
@@ -131,24 +126,14 @@ spec:
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
-                  {{- if .Values.secret.s3.secretRef }}
-                  name: {{ include "supabase.secret.s3.name" . | quote }}
-                  key: {{ include "supabase.secret.s3.key.keyId" . | quote }}
-                  {{- else }}
                   name: {{ include "supabase.secret.minio.name" . }}
                   key: {{ include "supabase.secret.minio.key.user" . }}
-                  {{- end }}
 
             - name: AWS_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  {{- if .Values.secret.s3.secretRef }}
-                  name: {{ include "supabase.secret.s3.name" . | quote }}
-                  key: {{ include "supabase.secret.s3.key.accessKey" . | quote }}
-                  {{- else }}
                   name: {{ include "supabase.secret.minio.name" . }}
                   key: {{ include "supabase.secret.minio.key.password" . }}
-                  {{- end }}
             {{- end }}
 
             {{- include "supabase.db.hostEnv" (dict "root" . "name" "DB_HOST") | nindent 12 }}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Related to #209

The MinIO and storage deployments reference a `supabase-s3` secret with keys `password` and `keyId`/`accessKey`. However, the generated `supabase-s3` secret only contains:

```yaml
keyId
accessKey
```

It does not contain a `password` key. This causes MinIO to fail at startup with `CreateContainerConfigError` because the referenced secret key does not exist.

## What is the new behavior?

This PR aligns the MinIO and storage deployments to consistently use the `supabase-minio` secret, which contains the expected `user` and `password` keys:

```yaml
- name: MINIO_ROOT_PASSWORD
  valueFrom:
    secretKeyRef:
      name: {{ include "supabase.secret.minio.name" . }}
      key: {{ include "supabase.secret.minio.key.password" . }}
```

This ensures MinIO can start successfully using credentials that actually exist in the referenced secret.

## Additional context

Files changed:
- `charts/supabase/templates/minio/deployment.yaml`
- `charts/supabase/templates/storage/deployment.yaml`

