### PR TITLE
feat(deployment): expose initDb and extraInitContainers

### DIFF
--- a/charts/supabase/templates/analytics/deployment.yaml
+++ b/charts/supabase/templates/analytics/deployment.yaml
@@ -52,6 +52,7 @@ spec:
       priorityClassName: {{ . }}
       {{- end }}
       initContainers:
+      {{- if .Values.deployment.analytics.initDb }}
         - name: init-db
           image: "{{ .Values.image.initDb.repository }}:{{ .Values.image.initDb.tag }}"
           imagePullPolicy: {{ .Values.image.initDb.pullPolicy }}
@@ -66,6 +67,10 @@ spec:
               sleep 2
               done
             - echo "Database is ready"
+      {{- end }}
+      {{- with .Values.deployment.analytics.extraInitContainers }}
+          {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ include "supabase.analytics.name" $ }}
           image: "{{ .Values.image.analytics.repository }}:{{ .Values.image.analytics.tag | default .Chart.AppVersion }}"

--- a/charts/supabase/templates/auth/deployment.yaml
+++ b/charts/supabase/templates/auth/deployment.yaml
@@ -52,6 +52,7 @@ spec:
       priorityClassName: {{ . }}
       {{- end }}
       initContainers:
+      {{- if .Values.deployment.auth.initDb }}
         - name: init-db
           image: "{{ .Values.image.initDb.repository }}:{{ .Values.image.initDb.tag }}"
           imagePullPolicy: {{ .Values.image.initDb.pullPolicy }}
@@ -66,6 +67,10 @@ spec:
               sleep 2
               done
             - echo "Database is ready"
+      {{- end }}
+      {{- with .Values.deployment.auth.extraInitContainers }}
+          {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ include "supabase.auth.name" $ }}
           image: "{{ .Values.image.auth.repository }}:{{ .Values.image.auth.tag | default .Chart.AppVersion }}"

--- a/charts/supabase/templates/db/statefulset.yaml
+++ b/charts/supabase/templates/db/statefulset.yaml
@@ -69,6 +69,7 @@ spec:
           volumeMounts:
             - mountPath: /mnt/pgsodium
               name: pgsodium
+      {{- if .Values.deployment.db.initDb }}
         - name: init-db
           image: "{{ .Values.image.db.repository }}:{{ .Values.image.db.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.db.pullPolicy }}
@@ -96,8 +97,9 @@ spec:
               name: custom-migrations
             - mountPath: /initdb.d
               name: initdb-scripts-data
-      {{- if .Values.deployment.db.extraInitContainers }}
-          {{- toYaml .Values.deployment.db.extraInitContainers | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.db.extraInitContainers }}
+          {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
         - name: {{ include "supabase.db.name" $ }}

--- a/charts/supabase/templates/functions/deployment.yaml
+++ b/charts/supabase/templates/functions/deployment.yaml
@@ -61,6 +61,10 @@ spec:
       {{- with .Values.deployment.functions.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
+      {{- with .Values.deployment.functions.extraInitContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ include "supabase.functions.name" $ }}
           image: "{{ .Values.image.functions.repository }}:{{ .Values.image.functions.tag | default .Chart.AppVersion }}"

--- a/charts/supabase/templates/realtime/deployment.yaml
+++ b/charts/supabase/templates/realtime/deployment.yaml
@@ -52,6 +52,7 @@ spec:
       priorityClassName: {{ . }}
       {{- end }}
       initContainers:
+      {{- if .Values.deployment.realtime.initDb }}
         - name: init-db
           image: "{{ .Values.image.initDb.repository }}:{{ .Values.image.initDb.tag }}"
           imagePullPolicy: {{ .Values.image.initDb.pullPolicy }}
@@ -66,6 +67,10 @@ spec:
               sleep 2
               done
             - echo "Database is ready"
+      {{- end }}
+      {{- with .Values.deployment.realtime.extraInitContainers }}
+          {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ include "supabase.realtime.name" $ }}
           image: "{{ .Values.image.realtime.repository }}:{{ .Values.image.realtime.tag | default .Chart.AppVersion }}"

--- a/charts/supabase/templates/rest/deployment.yaml
+++ b/charts/supabase/templates/rest/deployment.yaml
@@ -52,6 +52,7 @@ spec:
       priorityClassName: {{ . }}
       {{- end }}
       initContainers:
+      {{- if .Values.deployment.rest.initDb }}
         - name: init-db
           image: "{{ .Values.image.initDb.repository }}:{{ .Values.image.initDb.tag }}"
           imagePullPolicy: {{ .Values.image.initDb.pullPolicy }}
@@ -66,6 +67,10 @@ spec:
               sleep 2
               done
             - echo "Database is ready"
+      {{- end }}
+      {{- with .Values.deployment.rest.extraInitContainers }}
+          {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ include "supabase.rest.name" $ }}
           image: "{{ .Values.image.rest.repository }}:{{ .Values.image.rest.tag | default .Chart.AppVersion }}"

--- a/charts/supabase/templates/storage/deployment.yaml
+++ b/charts/supabase/templates/storage/deployment.yaml
@@ -52,6 +52,7 @@ spec:
       priorityClassName: {{ . }}
       {{- end }}
       initContainers:
+      {{- if .Values.deployment.storage.initDb }}
         - name: init-db
           image: "{{ .Values.image.initDb.repository }}:{{ .Values.image.initDb.tag }}"
           imagePullPolicy: {{ .Values.image.initDb.pullPolicy }}
@@ -66,7 +67,8 @@ spec:
               sleep 2
               done
             - echo "Database is ready"
-        {{- if .Values.deployment.minio.enabled }}
+      {{- end }}
+      {{- if .Values.deployment.minio.enabled }}
         - name: init-bucket
           image: "{{ .Values.image.minioClient.repository }}:{{ .Values.image.minioClient.tag }}"
           env:
@@ -98,8 +100,8 @@ spec:
               done
               /usr/bin/mc mb --ignore-existing supa-minio/$GLOBAL_S3_BUCKET
         {{- end }}
-        {{- if .Values.deployment.storage.extraInitContainers }}
-          {{ .Values.deployment.storage.extraInitContainers | toYaml | nindent 8 }}
+        {{- with .Values.deployment.storage.extraInitContainers }}
+          {{ . | toYaml | nindent 8 }}
         {{- end }}
       containers:
         - name: {{ include "supabase.storage.name" $ }}

--- a/charts/supabase/values.yaml
+++ b/charts/supabase/values.yaml
@@ -246,6 +246,8 @@ deployment:
     resources: {}
     volumeMounts: {}
     volumes: {}
+    extraInitContainers: []
+    initDb: true
 
   auth:
     enabled: true
@@ -270,6 +272,8 @@ deployment:
     resources: {}
     volumeMounts: {}
     volumes: {}
+    extraInitContainers: []
+    initDb: true
 
   db:
     enabled: true
@@ -295,6 +299,7 @@ deployment:
     volumeMounts: {}
     volumes: {}
     extraInitContainers: []
+    initDb: true
 
   functions:
     enabled: true
@@ -320,6 +325,7 @@ deployment:
     volumeMounts: {}
     volumes: {}
     strategy: {}
+    extraInitContainers: []
 
   imgproxy:
     enabled: true
@@ -440,6 +446,8 @@ deployment:
     resources: {}
     volumeMounts: {}
     volumes: {}
+    extraInitContainers: []
+    initDb: true
 
   rest:
     enabled: true
@@ -464,6 +472,8 @@ deployment:
     resources: {}
     volumeMounts: {}
     volumes: {}
+    extraInitContainers: []
+    initDb: true
 
   storage:
     enabled: true
@@ -489,6 +499,7 @@ deployment:
     volumeMounts: {}
     volumes: {}
     extraInitContainers: []
+    initDb: true
 
   studio:
     enabled: true


### PR DESCRIPTION
## What kind of change does this PR introduce?

**Feature**

Support disabling the `init-db` initContainers (see https://github.com/supabase-community/supabase-kubernetes/issues/225)

## What is the current behavior?

Currently the `init-db` initContainers are not explicitly configurable.

## What is the new behavior?

No change by default, new `initDb` value for relevant deployments that can be set to false to disable the `init-db` initContainer.

To override with custom behavior, add an item to the corresponding `extraInitContainers` list.

## Additional context

Add any other context or screenshots.
