### PR TITLE
feat(kong): support existing ConfigMap

### DIFF
--- a/charts/supabase/templates/kong/_helpers.tpl
+++ b/charts/supabase/templates/kong/_helpers.tpl
@@ -41,3 +41,10 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.kong.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create the name of the config map to use
+*/}}
+{{- define "supabase.kong.configMapName" -}}
+{{- default (include "supabase.kong.fullname" .) .Values.deployment.kong.configMapRef }}
+{{- end }}

--- a/charts/supabase/templates/kong/config.yaml
+++ b/charts/supabase/templates/kong/config.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.deployment.kong.enabled -}}
+{{- if and .Values.deployment.kong.enabled (not .Values.deployment.kong.configMapRef) -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/supabase/templates/kong/deployment.yaml
+++ b/charts/supabase/templates/kong/deployment.yaml
@@ -153,14 +153,14 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: {{ include "supabase.kong.fullname" $ }}
+            name: {{ include "supabase.kong.configMapName" $ }}
             defaultMode: 0777
             items:
             - key: kong.yml
               path: template.yml
         - name: wrapper
           configMap:
-            name: {{ include "supabase.kong.fullname" $ }}
+            name: {{ include "supabase.kong.configMapName" $ }}
             defaultMode: 0777
             items:
             - key: kong-entrypoint.sh

--- a/charts/supabase/values.yaml
+++ b/charts/supabase/values.yaml
@@ -350,6 +350,7 @@ deployment:
     replicaCount: 1
     nameOverride: ""
     fullnameOverride: ""
+    configMapRef: ""
     annotations: {}
     podAnnotations: {}
     podSecurityContext:


### PR DESCRIPTION
## What kind of change does this PR introduce?

**Feature**

Support referencing an existing ConfigMap for kong config + entrypoint

## What is the current behavior?

The ConfigMap is generated from the kong.yml and kong-entrypoint.sh files in the chart and the deployment mounts it as a volume.

## What is the new behavior?

No change by default. If `deployment.kong.configMapRef` is not empty, the default config map will not be created and the value of `deployment.kong.configMapRef` will be used as the name in the configMapRef for the volume.

## Additional context

This allows for custom behavior like adding a prefix to routes, routing to external instances of realtime and imgproxy, etc.

The current workaround for this would be to disable the supabase kong deployment and deploy kong separately. 