### PR TITLE
feat(deployment): expose labels

### DIFF
--- a/charts/supabase/templates/analytics/deployment.yaml
+++ b/charts/supabase/templates/analytics/deployment.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+    {{- with .Values.deployment.analytics.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.deployment.analytics.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/supabase/templates/auth/deployment.yaml
+++ b/charts/supabase/templates/auth/deployment.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+    {{- with .Values.deployment.auth.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}    
   {{- with .Values.deployment.auth.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/supabase/templates/db/statefulset.yaml
+++ b/charts/supabase/templates/db/statefulset.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+    {{- with .Values.deployment.db.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.deployment.db.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/supabase/templates/functions/deployment.yaml
+++ b/charts/supabase/templates/functions/deployment.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+    {{- with .Values.deployment.functions.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.deployment.functions.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/supabase/templates/imgproxy/deployment.yaml
+++ b/charts/supabase/templates/imgproxy/deployment.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+    {{- with .Values.deployment.imgproxy.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.deployment.imgproxy.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/supabase/templates/kong/deployment.yaml
+++ b/charts/supabase/templates/kong/deployment.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+    {{- with .Values.deployment.kong.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.deployment.kong.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/supabase/templates/meta/deployment.yaml
+++ b/charts/supabase/templates/meta/deployment.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+    {{- with .Values.deployment.meta.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.deployment.meta.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/supabase/templates/minio/deployment.yaml
+++ b/charts/supabase/templates/minio/deployment.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+    {{- with .Values.deployment.minio.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.deployment.minio.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/supabase/templates/realtime/deployment.yaml
+++ b/charts/supabase/templates/realtime/deployment.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+    {{- with .Values.deployment.realtime.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.deployment.realtime.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/supabase/templates/rest/deployment.yaml
+++ b/charts/supabase/templates/rest/deployment.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+    {{- with .Values.deployment.rest.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.deployment.rest.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/supabase/templates/storage/deployment.yaml
+++ b/charts/supabase/templates/storage/deployment.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+    {{- with .Values.deployment.storage.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.deployment.storage.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/supabase/templates/studio/deployment.yaml
+++ b/charts/supabase/templates/studio/deployment.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+    {{- with .Values.deployment.studio.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.deployment.studio.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/supabase/templates/vector/deployment.yaml
+++ b/charts/supabase/templates/vector/deployment.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+    {{- with .Values.deployment.vector.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
     vector.dev/exclude: "true"
   {{- with .Values.deployment.vector.annotations }}
   annotations:

--- a/charts/supabase/values.yaml
+++ b/charts/supabase/values.yaml
@@ -228,6 +228,7 @@ deployment:
     replicaCount: 1
     nameOverride: ""
     fullnameOverride: ""
+    labels: {}
     annotations: {}
     podAnnotations: {}
     podSecurityContext:
@@ -252,6 +253,7 @@ deployment:
     replicaCount: 1
     nameOverride: ""
     fullnameOverride: ""
+    labels: {}
     annotations: {}
     podAnnotations: {}
     podSecurityContext:
@@ -276,6 +278,7 @@ deployment:
     replicaCount: 1
     nameOverride: ""
     fullnameOverride: ""
+    labels: {}
     annotations: {}
     podAnnotations: {}
     podSecurityContext:
@@ -327,6 +330,7 @@ deployment:
     replicaCount: 1
     nameOverride: ""
     fullnameOverride: ""
+    labels: {}
     annotations: {}
     podAnnotations: {}
     podSecurityContext:
@@ -351,6 +355,7 @@ deployment:
     replicaCount: 1
     nameOverride: ""
     fullnameOverride: ""
+    labels: {}
     annotations: {}
     podAnnotations: {}
     podSecurityContext:
@@ -375,6 +380,7 @@ deployment:
     replicaCount: 1
     nameOverride: ""
     fullnameOverride: ""
+    labels: {}
     annotations: {}
     podAnnotations: {}
     podSecurityContext:
@@ -399,6 +405,7 @@ deployment:
     replicaCount: 1
     nameOverride: ""
     fullnameOverride: ""
+    labels: {}
     annotations: {}
     podAnnotations: {}
     podSecurityContext:
@@ -423,6 +430,7 @@ deployment:
     replicaCount: 1
     nameOverride: ""
     fullnameOverride: ""
+    labels: {}
     annotations: {}
     podAnnotations: {}
     podSecurityContext:
@@ -447,6 +455,7 @@ deployment:
     replicaCount: 1
     nameOverride: ""
     fullnameOverride: ""
+    labels: {}
     annotations: {}
     podAnnotations: {}
     podSecurityContext:
@@ -471,6 +480,7 @@ deployment:
     replicaCount: 1
     nameOverride: ""
     fullnameOverride: ""
+    labels: {}
     annotations: {}
     podAnnotations: {}
     podSecurityContext:
@@ -496,6 +506,7 @@ deployment:
     replicaCount: 1
     nameOverride: ""
     fullnameOverride: ""
+    labels: {}
     annotations: {}
     podAnnotations: {}
     podSecurityContext:
@@ -525,6 +536,7 @@ deployment:
     replicaCount: 1
     nameOverride: ""
     fullnameOverride: ""
+    labels: {}
     annotations: {}
     podAnnotations: {}
     podSecurityContext:

--- a/charts/supabase/values.yaml
+++ b/charts/supabase/values.yaml
@@ -301,6 +301,7 @@ deployment:
     replicaCount: 1
     nameOverride: ""
     fullnameOverride: ""
+    labels: {}
     annotations: {}
     podAnnotations: {}
     podSecurityContext:


### PR DESCRIPTION
## What kind of change does this PR introduce?

**Feature**

Support defining additional deployment labels, see #225 

## What is the current behavior?

Labels are rendered by the `supabase.labels` helper which includes `helm.sh/chart`, `app.kubernetes.io/version`, `app.kubernetes.io/managed-by`, `app.kubernetes.io/name`, `app.kubernetes.io/instance`

## What is the new behavior?

No change by default, if additional labels are defined in the the deployment's labels object, they are included as well.

## Additional context

The chart already allows specifying annotations in this way for deployments and the same pattern is used in services.

Custom labels are useful for CI workflows, etc
