### PR TITLE
feat(deployment): expose dnsPolicy and dnsConfig

### DIFF
--- a/charts/supabase/templates/auth/deployment.yaml
+++ b/charts/supabase/templates/auth/deployment.yaml
@@ -26,6 +26,13 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- with .Values.deployment.auth.dnsPolicy }}
+      dnsPolicy: {{ . }}
+      {{- end }}
+      {{- with .Values.deployment.auth.dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "supabase.auth.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.deployment.auth.automountServiceAccountToken }}
       restartPolicy: Always

--- a/charts/supabase/templates/realtime/deployment.yaml
+++ b/charts/supabase/templates/realtime/deployment.yaml
@@ -26,6 +26,13 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- with .Values.deployment.realtime.dnsPolicy }}
+      dnsPolicy: {{ . }}
+      {{- end }}
+      {{- with .Values.deployment.realtime.dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "supabase.realtime.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.deployment.realtime.automountServiceAccountToken }}
       restartPolicy: Always

--- a/charts/supabase/values.yaml
+++ b/charts/supabase/values.yaml
@@ -262,6 +262,8 @@ deployment:
     affinity: {}
     tolerations: []
     priorityClassName: ""
+    dnsPolicy: ""
+    dnsConfig: {}
     envFrom: []
     livenessProbe: {}
     readinessProbe: {}

--- a/charts/supabase/values.yaml
+++ b/charts/supabase/values.yaml
@@ -434,6 +434,8 @@ deployment:
     affinity: {}
     tolerations: []
     priorityClassName: ""
+    dnsPolicy: ""
+    dnsConfig: {}
     envFrom: []
     livenessProbe: {}
     readinessProbe: {}


### PR DESCRIPTION
## What kind of change does this PR introduce?

**Feature**

Expose `dnsConfig` and `dnsPolicy` for auth and realtime deployments, see #225 

## What is the current behavior?

`dnsConfig` and `dnsPolicy` are not currently configurable

## What is the new behavior?

No change by default, set corresponding value to override behavior.

## Additional context

These two services were resolving the IPv6 address for an external DB on a mixed IPv4/IPv6 network when the IPv4 address was required. Allowing the `dnsConfig` and `dnsPolicy` to be configurable allows side-stepping the problem.