### PR TITLE
chore(studio): bump default image tag

### DIFF
--- a/charts/supabase/values.yaml
+++ b/charts/supabase/values.yaml
@@ -642,7 +642,7 @@ image:
   studio:
     repository: supabase/studio
     pullPolicy: IfNotPresent
-    tag: "2026.06.03-sha-0bca601"
+    tag: "2026.07.07-sha-a6a04f2"
     pullSecrets: []
 
   vector:


### PR DESCRIPTION
Bump default Studio tag:

- studio: 2026.06.03-sha-0bca601 -> 2026.07.07-sha-a6a04f2