### PR TITLE
feat(realtime): generate realtime db encryption key in secrets

### DIFF
--- a/charts/supabase/templates/realtime/deployment.yaml
+++ b/charts/supabase/templates/realtime/deployment.yaml
@@ -144,6 +144,11 @@ spec:
                 secretKeyRef:
                   name: {{ include "supabase.secret.realtime.name" . }}
                   key: {{ include "supabase.secret.realtime.key.secretKeyBase" . }}
+            - name: DB_ENC_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "supabase.secret.realtime.name" . }}
+                  key: {{ include "supabase.secret.realtime.key.dbEncKey" . }}
           {{- with .Values.deployment.realtime.envFrom }}
           envFrom:
             {{- toYaml . | nindent 12 }}

--- a/charts/supabase/templates/secret/realtime.yaml
+++ b/charts/supabase/templates/secret/realtime.yaml
@@ -10,6 +10,10 @@
 {{- index (default (dict) .Values.secret.realtime.secretRefKey) "secretKeyBase" | default "secretKeyBase" -}}
 {{- end -}}
 
+{{- define "supabase.secret.realtime.key.dbEncKey" -}}
+{{- index (default (dict) .Values.secret.realtime.secretRefKey) "dbEncKey" | default "dbEncKey" -}}
+{{- end -}}
+
 {{- if not .Values.secret.realtime.secretRef }}
 apiVersion: v1
 kind: Secret
@@ -20,4 +24,5 @@ metadata:
 type: Opaque
 data:
   secretKeyBase: {{ .Values.secret.realtime.secretKeyBase | b64enc | quote }}
+  dbEncKey: {{ .Values.secret.realtime.dbEncKey | b64enc | quote }}
 {{- end }}

--- a/charts/supabase/values.yaml
+++ b/charts/supabase/values.yaml
@@ -188,12 +188,17 @@ secret:
     ## Generate with: openssl rand -base64 64
     secretKeyBase: "UpNVntn3cDxHJpq99YMc1T1AQgQpc8kfYTuRgBiYa15BLrx8etQoXz3gZv1/u2oq"
 
+    ## Encryption key used by Realtime for sensitive fields in the _realtime schema.
+    ## Must be exactly 16 characters. Generate with: openssl rand -hex 8
+    dbEncKey: "supabaserealtime"
+
     ## Reference to existing secret
     # secretRef: ""
 
     ## Map to actual keys inside secretRef if they differ
     # secretRefKey:
     #   secretKeyBase: secretKeyBase
+    #   dbEncKey: dbEncKey
 
   ## Meta service
   ## Docs: https://github.com/supabase/postgres-meta
@@ -773,7 +778,6 @@ environment:
     FLY_APP_NAME: realtime
     ENABLE_TAILSCALE: "false"
     DB_AFTER_CONNECT_QUERY: "SET search_path TO _realtime"
-    DB_ENC_KEY: supabaserealtime
     ERL_AFLAGS: -proto_dist inet_tcp
     DNS_NODES: "''"
     RLIMIT_NOFILE: "10000"

--- a/internal/controller/project.go
+++ b/internal/controller/project.go
@@ -769,6 +769,7 @@ func (r *ProjectReconciler) ensureKeysSecret(ctx context.Context, proj *supabase
 		project.KeysSecretSecretKeyBase,
 		project.KeysSecretCryptoKey,
 		project.KeysSecretVaultEncKey,
+		project.KeysSecretRealtimeDBEncKey,
 	))
 	if err != nil {
 		return fmt.Errorf("ensuring keys secret: %w", err)

--- a/internal/project/keys_secret.go
+++ b/internal/project/keys_secret.go
@@ -35,6 +35,9 @@ const (
 
 	// KeysSecretVaultEncKey is the Secret data key that holds the Vault encryption key.
 	KeysSecretVaultEncKey = "vault-enc-key"
+
+	// KeysSecretRealtimeDBEncKey is the Secret data key that holds the Realtime DB encryption key.
+	KeysSecretRealtimeDBEncKey = "realtime-db-enc-key"
 )
 
 // KeysSecretName returns the name of the Keys Secret for a Project.
@@ -59,6 +62,11 @@ func KeysSecret(project *supabasev1alpha1.Project) (*corev1.Secret, error) {
 		return nil, fmt.Errorf("generating vault encryption key: %w", err)
 	}
 
+	realtimeDBEncKey, err := helper.GenerateRandomHex(8)
+	if err != nil {
+		return nil, fmt.Errorf("generating realtime db encryption key: %w", err)
+	}
+
 	sc := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      KeysSecretName(project),
@@ -67,9 +75,10 @@ func KeysSecret(project *supabasev1alpha1.Project) (*corev1.Secret, error) {
 		},
 		Type: corev1.SecretTypeOpaque,
 		Data: map[string][]byte{
-			KeysSecretSecretKeyBase: []byte(secretKeyBase),
-			KeysSecretCryptoKey:     []byte(cryptoKey),
-			KeysSecretVaultEncKey:   []byte(vaultEncKey),
+			KeysSecretSecretKeyBase:    []byte(secretKeyBase),
+			KeysSecretCryptoKey:        []byte(cryptoKey),
+			KeysSecretVaultEncKey:      []byte(vaultEncKey),
+			KeysSecretRealtimeDBEncKey: []byte(realtimeDBEncKey),
 		},
 	}
 

--- a/internal/project/realtime_deployment.go
+++ b/internal/project/realtime_deployment.go
@@ -198,7 +198,7 @@ func buildRealtimeEnvVars(project *supabasev1alpha1.Project, db *supabasev1alpha
 		helper.EnvVarFromSecret("DB_PASSWORD", db.PasswordRef.Name, db.PasswordRef.Key),
 		helper.EnvVar("DB_NAME", db.DBName),
 		helper.EnvVar("DB_AFTER_CONNECT_QUERY", "SET search_path TO _realtime"),
-		helper.EnvVar("DB_ENC_KEY", "supabaserealtime"),
+		helper.EnvVarFromSecret("DB_ENC_KEY", KeysSecretName(project), KeysSecretRealtimeDBEncKey),
 		helper.EnvVarFromSecret("API_JWT_SECRET", JWTSecretName(project), JWTSecretKey),
 		helper.EnvVarFromSecret("API_JWT_JWKS", JWTSecretName(project), JWTSecretJWKS),
 		helper.EnvVarFromSecret("SECRET_KEY_BASE", KeysSecretName(project), KeysSecretSecretKeyBase),


### PR DESCRIPTION
## Summary
Removes the hardcoded Realtime `DB_ENC_KEY` (`supabaserealtime`) and moves it to a generated Secret.

## Changes
- Operator: add `realtime-db-enc-key` to the managed Keys Secret, generated with 16 hex characters.
- Operator: read `DB_ENC_KEY` from the Secret in the Realtime Deployment.
- Helm chart: add `secret.realtime.dbEncKey` with backward-compatible default `supabaserealtime`.
- Helm chart: render `DB_ENC_KEY` from the Realtime Secret in the deployment template.
- Remove hardcoded `DB_ENC_KEY` from `environment.realtime` values.

## Backward compatibility
The Helm chart keeps `supabaserealtime` as the default value for existing deployments. The operator generates a random key for new installations.

## Additional Context

- Related: https://github.com/supabase/supabase/pull/46021
Closes #77 