### PR TITLE
feat(chart)!: use first-class Kubernetes env array for environment.<component>

### DIFF
--- a/charts/supabase/Chart.yaml
+++ b/charts/supabase/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.0
+version: 0.7.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/supabase/README.md
+++ b/charts/supabase/README.md
@@ -201,20 +201,46 @@ Supabase storage supports the use of S3 object-storage. To enable S3 for Supabas
   ```
 2. Set storage S3 environment variables:
   ```yaml
-  storage:
-    environment:
-      # Set S3 endpoint if using external object-storage
-      # GLOBAL_S3_ENDPOINT: http://minio:9000
-      STORAGE_BACKEND: s3
-      GLOBAL_S3_PROTOCOL: http
-      GLOBAL_S3_FORCE_PATH_STYLE: true
-      AWS_DEFAULT_REGION: stub
+
+  environment:
+    auth:
+      - name: API_EXTERNAL_URL
+        value: http://supabase.local
+      - name: GOTRUE_SITE_URL
+        value: http://supabase.local
+      - name: GOTRUE_URI_ALLOW_LIST
+        value: "*"
+      - name: GOTRUE_EXTERNAL_AZURE_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: azure-secret
+            key: secret
   ```
 3. (Optional) Enable internal minio deployment
   ```yaml
   minio:
     enabled: true
   ```
+
+### Environment variables
+
+> [!NOTE]
+> Starting with chart version `0.7.1`, `environment.<component>` is an array of Kubernetes env entries instead of a map. Each entry supports `value:` or `valueFrom:`.
+
+Example:
+```yaml
+environment:
+  auth:
+    - name: GOTRUE_API_HOST
+      value: "0.0.0.0"
+    - name: GOTRUE_EXTERNAL_AZURE_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: azure-secret
+          key: secret
+```
+
+User-provided entries are rendered after the chart defaults, so any chart-managed env var can be overridden by adding an entry with the same `name` to the component array.
 
 ## How to use in Production
 

--- a/charts/supabase/ci/example.yaml
+++ b/charts/supabase/ci/example.yaml
@@ -39,3 +39,11 @@ persistence:
 
   storage:
     enabled: false
+
+environment:
+  auth:
+    - name: GOTRUE_EXTERNAL_AZURE_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: azure-secret
+          key: secret

--- a/charts/supabase/templates/_helpers.tpl
+++ b/charts/supabase/templates/_helpers.tpl
@@ -60,3 +60,19 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Render environment variables from a list of { name, value | valueFrom } entries.
+All plain values are forced to strings so Kubernetes accepts them.
+*/}}
+{{- define "supabase.env.render" -}}
+{{- range .env }}
+- name: {{ .name }}
+{{- if hasKey . "value" }}
+  value: {{ .value | quote }}
+{{- else if hasKey . "valueFrom" }}
+  valueFrom:
+    {{- .valueFrom | toYaml | nindent 4 }}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/supabase/templates/analytics/deployment.yaml
+++ b/charts/supabase/templates/analytics/deployment.yaml
@@ -82,6 +82,12 @@ spec:
             - containerPort: {{ .Values.service.analytics.port }}
               protocol: TCP
           env:
+            - name: DB_DRIVER
+              value: "postgresql"
+            - name: DB_USERNAME
+              value: "supabase_admin"
+            - name: DB_DATABASE
+              value: "_supabase"
             {{- include "supabase.db.hostEnv" (dict "root" . "name" "DB_HOSTNAME") | nindent 12 }}
             {{- include "supabase.db.portEnv" (dict "root" . "name" "DB_PORT") | nindent 12 }}
             - name: DB_PASSWORD

--- a/charts/supabase/templates/analytics/deployment.yaml
+++ b/charts/supabase/templates/analytics/deployment.yaml
@@ -82,12 +82,6 @@ spec:
             - containerPort: {{ .Values.service.analytics.port }}
               protocol: TCP
           env:
-            {{- range $key, $value := .Values.environment.analytics }}
-            {{- if and (ne $key "DB_HOST") (ne $key "DB_PORT") }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
-            {{- end }}
-            {{- end }}
             {{- include "supabase.db.hostEnv" (dict "root" . "name" "DB_HOSTNAME") | nindent 12 }}
             {{- include "supabase.db.portEnv" (dict "root" . "name" "DB_PORT") | nindent 12 }}
             - name: DB_PASSWORD
@@ -119,6 +113,7 @@ spec:
             - name: POSTGRES_BACKEND_URL
               value: $(DB_DRIVER)://$(DB_USERNAME):$(DB_PASSWORD_ENC)@$(DB_HOSTNAME):$(DB_PORT)/$(DB_DATABASE)
             {{- end }}
+            {{- include "supabase.env.render" (dict "env" .Values.environment.analytics) | nindent 12 }}
           {{- with .Values.deployment.analytics.envFrom }}
           envFrom:
             {{- toYaml . | nindent 12 }}

--- a/charts/supabase/templates/auth/deployment.yaml
+++ b/charts/supabase/templates/auth/deployment.yaml
@@ -90,12 +90,6 @@ spec:
               containerPort: 9999
               protocol: TCP
           env:
-            {{- range $key, $value := .Values.environment.auth }}
-            {{- if and (ne $key "DB_HOST") (ne $key "DB_PORT") }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
-            {{- end }}
-            {{- end }}
             {{- include "supabase.db.hostEnv" (dict "root" . "name" "DB_HOST") | nindent 12 }}
             {{- include "supabase.db.portEnv" (dict "root" . "name" "DB_PORT") | nindent 12 }}
             - name: DB_PASSWORD
@@ -143,6 +137,7 @@ spec:
                 secretKeyRef:
                   name: {{ include "supabase.secret.smtp.name" . }}
                   key: {{ include "supabase.secret.smtp.key.password" . }}
+            {{- include "supabase.env.render" (dict "env" .Values.environment.auth) | nindent 12 }}
           {{- with .Values.deployment.auth.envFrom }}
           envFrom:
             {{- toYaml . | nindent 12 }}

--- a/charts/supabase/templates/auth/deployment.yaml
+++ b/charts/supabase/templates/auth/deployment.yaml
@@ -90,6 +90,12 @@ spec:
               containerPort: 9999
               protocol: TCP
           env:
+            - name: DB_DRIVER
+              value: "postgres"
+            - name: DB_USER
+              value: "supabase_auth_admin"
+            - name: DB_SSL
+              value: "disable"
             {{- include "supabase.db.hostEnv" (dict "root" . "name" "DB_HOST") | nindent 12 }}
             {{- include "supabase.db.portEnv" (dict "root" . "name" "DB_PORT") | nindent 12 }}
             - name: DB_PASSWORD

--- a/charts/supabase/templates/db/statefulset.yaml
+++ b/charts/supabase/templates/db/statefulset.yaml
@@ -117,10 +117,6 @@ spec:
               containerPort: 5432
               protocol: TCP
           env:
-            {{- range $key, $value := .Values.environment.db }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
-            {{- end }}
             - name: PGPASSWORD
               valueFrom:
                 secretKeyRef:
@@ -146,6 +142,7 @@ spec:
                 secretKeyRef:
                   name: {{ include "supabase.secret.jwt.name" . }}
                   key: {{ include "supabase.secret.jwt.key.secret" . }}
+            {{- include "supabase.env.render" (dict "env" .Values.environment.db) | nindent 12 }}
           {{- with .Values.deployment.db.envFrom }}
           envFrom:
             {{- toYaml . | nindent 12 }}

--- a/charts/supabase/templates/functions/deployment.yaml
+++ b/charts/supabase/templates/functions/deployment.yaml
@@ -77,13 +77,6 @@ spec:
             - --main-service
             - /home/deno/functions/main
           env:
-            {{- range $key, $value := .Values.environment.functions }}
-            {{- if and (ne $key "DB_HOST") (ne $key "DB_PORT") }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
-            {{- end }}
-            {{- end }}
-
             {{- if .Values.deployment.kong.enabled }}
             - name: SUPABASE_URL
               value: http://{{ include "supabase.kong.fullname" . }}:{{ .Values.service.kong.port }}
@@ -141,6 +134,7 @@ spec:
               value: '{"default":"$(SUPABASE_SECRET_KEY)"}'
             - name: SUPABASE_DB_URL
               value: $(DB_DRIVER)://$(DB_USERNAME):$(DB_PASSWORD_ENC)@$(DB_HOSTNAME):$(DB_PORT)/$(DB_DATABASE)?search_path=auth&sslmode=$(DB_SSL)
+            {{- include "supabase.env.render" (dict "env" .Values.environment.functions) | nindent 12 }}
           {{- if .Values.deployment.functions.envFrom }}
           envFrom:
             {{- toYaml .Values.deployment.functions.envFrom | nindent 12 }}

--- a/charts/supabase/templates/functions/deployment.yaml
+++ b/charts/supabase/templates/functions/deployment.yaml
@@ -82,6 +82,12 @@ spec:
               value: http://{{ include "supabase.kong.fullname" . }}:{{ .Values.service.kong.port }}
             {{- end }}
 
+            - name: DB_DRIVER
+              value: "postgresql"
+            - name: DB_USERNAME
+              value: "postgres"
+            - name: DB_SSL
+              value: "disable"
             {{- include "supabase.db.hostEnv" (dict "root" . "name" "DB_HOSTNAME") | nindent 12 }}
             {{- include "supabase.db.portEnv" (dict "root" . "name" "DB_PORT") | nindent 12 }}
             - name: DB_PASSWORD

--- a/charts/supabase/templates/imgproxy/deployment.yaml
+++ b/charts/supabase/templates/imgproxy/deployment.yaml
@@ -63,10 +63,7 @@ spec:
               containerPort: 8080
               protocol: TCP
           env:
-            {{- range $key, $value := .Values.environment.imgproxy }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
-            {{- end }}
+            {{- include "supabase.env.render" (dict "env" .Values.environment.imgproxy) | nindent 12 }}
           {{- with .Values.deployment.imgproxy.envFrom }}
           envFrom:
             {{- toYaml . | nindent 12 }}

--- a/charts/supabase/templates/kong/deployment.yaml
+++ b/charts/supabase/templates/kong/deployment.yaml
@@ -72,10 +72,6 @@ spec:
               containerPort: 8000
               protocol: TCP
           env:
-            {{- range $key, $value := .Values.environment.kong }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
-            {{- end }}
             - name: SUPABASE_ANON_KEY
               valueFrom:
                 secretKeyRef:
@@ -118,6 +114,7 @@ spec:
                   name: {{ include "supabase.secret.dashboard.name" . }}
                   key: {{ include "supabase.secret.dashboard.key.password" . }}
             {{- end }}
+            {{- include "supabase.env.render" (dict "env" .Values.environment.kong) | nindent 12 }}
           {{- with .Values.deployment.kong.envFrom }}
           envFrom:
             {{- toYaml . | nindent 12 }}

--- a/charts/supabase/templates/meta/deployment.yaml
+++ b/charts/supabase/templates/meta/deployment.yaml
@@ -63,12 +63,6 @@ spec:
               containerPort: 8080
               protocol: TCP
           env:
-            {{- range $key, $value := .Values.environment.meta }}
-            {{- if and (ne $key "DB_HOST") (ne $key "DB_PORT") }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
-            {{- end }}
-            {{- end }}
             {{- include "supabase.db.hostEnv" (dict "root" . "name" "DB_HOST") | nindent 12 }}
             {{- include "supabase.db.portEnv" (dict "root" . "name" "DB_PORT") | nindent 12 }}
             - name: DB_PASSWORD
@@ -102,6 +96,7 @@ spec:
                 secretKeyRef:
                   name: {{ include "supabase.secret.meta.name" . }}
                   key: {{ include "supabase.secret.meta.key.cryptoKey" . }}
+            {{- include "supabase.env.render" (dict "env" .Values.environment.meta) | nindent 12 }}
           {{- with .Values.deployment.meta.envFrom }}
           envFrom:
             {{- toYaml . | nindent 12 }}

--- a/charts/supabase/templates/meta/deployment.yaml
+++ b/charts/supabase/templates/meta/deployment.yaml
@@ -63,6 +63,10 @@ spec:
               containerPort: 8080
               protocol: TCP
           env:
+            - name: DB_USER
+              value: "supabase_admin"
+            - name: DB_SSL
+              value: "disable"
             {{- include "supabase.db.hostEnv" (dict "root" . "name" "DB_HOST") | nindent 12 }}
             {{- include "supabase.db.portEnv" (dict "root" . "name" "DB_PORT") | nindent 12 }}
             - name: DB_PASSWORD

--- a/charts/supabase/templates/minio/deployment.yaml
+++ b/charts/supabase/templates/minio/deployment.yaml
@@ -78,6 +78,7 @@ spec:
                 secretKeyRef:
                   name: {{ include "supabase.secret.minio.name" . }}
                   key: {{ include "supabase.secret.minio.key.password" . }}
+            {{- include "supabase.env.render" (dict "env" .Values.environment.minio) | nindent 12 }}
           {{- with .Values.deployment.minio.envFrom }}
           envFrom:
             {{- toYaml . | nindent 12 }}

--- a/charts/supabase/templates/realtime/deployment.yaml
+++ b/charts/supabase/templates/realtime/deployment.yaml
@@ -92,12 +92,6 @@ spec:
               containerPort: 4000
               protocol: TCP
           env:
-            {{- range $key, $value := .Values.environment.realtime }}
-            {{- if and (ne $key "DB_HOST") (ne $key "DB_PORT") }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
-            {{- end }}
-            {{- end }}
             {{- include "supabase.db.hostEnv" (dict "root" . "name" "DB_HOST") | nindent 12 }}
             {{- include "supabase.db.portEnv" (dict "root" . "name" "DB_PORT") | nindent 12 }}
             - name: SELF_HOST_TENANT_NAME
@@ -149,6 +143,7 @@ spec:
                 secretKeyRef:
                   name: {{ include "supabase.secret.realtime.name" . }}
                   key: {{ include "supabase.secret.realtime.key.dbEncKey" . }}
+            {{- include "supabase.env.render" (dict "env" .Values.environment.realtime) | nindent 12 }}
           {{- with .Values.deployment.realtime.envFrom }}
           envFrom:
             {{- toYaml . | nindent 12 }}

--- a/charts/supabase/templates/rest/deployment.yaml
+++ b/charts/supabase/templates/rest/deployment.yaml
@@ -83,6 +83,12 @@ spec:
               containerPort: 3000
               protocol: TCP
           env:
+            - name: DB_DRIVER
+              value: "postgres"
+            - name: DB_USER
+              value: "authenticator"
+            - name: DB_SSL
+              value: "disable"
             {{- include "supabase.db.hostEnv" (dict "root" . "name" "DB_HOST") | nindent 12 }}
             {{- include "supabase.db.portEnv" (dict "root" . "name" "DB_PORT") | nindent 12 }}
             - name: DB_PASSWORD

--- a/charts/supabase/templates/rest/deployment.yaml
+++ b/charts/supabase/templates/rest/deployment.yaml
@@ -83,12 +83,6 @@ spec:
               containerPort: 3000
               protocol: TCP
           env:
-            {{- range $key, $value := .Values.environment.rest }}
-            {{- if and (ne $key "DB_HOST") (ne $key "DB_PORT") }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
-            {{- end }}
-            {{- end }}
             {{- include "supabase.db.hostEnv" (dict "root" . "name" "DB_HOST") | nindent 12 }}
             {{- include "supabase.db.portEnv" (dict "root" . "name" "DB_PORT") | nindent 12 }}
             - name: DB_PASSWORD
@@ -127,6 +121,7 @@ spec:
                 secretKeyRef:
                   name: {{ include "supabase.secret.jwt.name" . }}
                   key: {{ include "supabase.secret.jwt.key.secret" . }}
+            {{- include "supabase.env.render" (dict "env" .Values.environment.rest) | nindent 12 }}
           {{- with .Values.deployment.rest.envFrom }}
           envFrom:
             {{- toYaml . | nindent 12 }}

--- a/charts/supabase/templates/storage/deployment.yaml
+++ b/charts/supabase/templates/storage/deployment.yaml
@@ -111,6 +111,12 @@ spec:
           env:
             - name: STORAGE_BACKEND
               value: {{ if .Values.deployment.minio.enabled }}"s3"{{ else }}"file"{{ end }}
+            - name: DB_DRIVER
+              value: "postgres"
+            - name: DB_USER
+              value: "supabase_storage_admin"
+            - name: DB_SSL
+              value: "disable"
 
             {{- if or .Values.secret.s3.secretRef .Values.deployment.minio.enabled }}
             - name: AWS_ACCESS_KEY_ID

--- a/charts/supabase/templates/storage/deployment.yaml
+++ b/charts/supabase/templates/storage/deployment.yaml
@@ -85,8 +85,7 @@ spec:
                 secretKeyRef:
                   name: {{ include "supabase.secret.minio.name" . }}
                   key: {{ include "supabase.secret.minio.key.password" . }}
-            - name: GLOBAL_S3_BUCKET
-              value: {{ .Values.environment.storage.GLOBAL_S3_BUCKET }}
+            {{- include "supabase.env.render" (dict "env" .Values.environment.storage) | nindent 12 }}
           imagePullPolicy: {{ .Values.image.minioClient.pullPolicy }}
           command:
             - /bin/sh
@@ -110,22 +109,8 @@ spec:
               containerPort: 5000
               protocol: TCP
           env:
-            {{- range $key, $value := .Values.environment.storage }}
-            {{- if and (ne $key "AWS_ACCESS_KEY_ID") (ne $key "AWS_SECRET_ACCESS_KEY") (ne $key "STORAGE_BACKEND") (ne $key "DB_HOST") (ne $key "DB_PORT") }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
-            {{- end }}
-            {{- end }}
-            
-            # 2. Now handle STORAGE_BACKEND specifically
             - name: STORAGE_BACKEND
-              value: {{ if hasKey .Values.environment.storage "STORAGE_BACKEND" -}}
-                {{ index .Values.environment.storage "STORAGE_BACKEND" | quote }}
-              {{- else if .Values.deployment.minio.enabled -}}
-                "s3"
-              {{- else -}}
-                "file"
-              {{- end }}
+              value: {{ if .Values.deployment.minio.enabled }}"s3"{{ else }}"file"{{ end }}
 
             {{- if or .Values.secret.s3.secretRef .Values.deployment.minio.enabled }}
             - name: AWS_ACCESS_KEY_ID
@@ -218,6 +203,7 @@ spec:
             - name: GLOBAL_S3_FORCE_PATH_STYLE
               value: "true"
             {{- end }}
+            {{- include "supabase.env.render" (dict "env" .Values.environment.storage) | nindent 12 }}
           {{- with .Values.deployment.storage.envFrom }}
           envFrom:
             {{- toYaml . | nindent 12 }}

--- a/charts/supabase/templates/studio/deployment.yaml
+++ b/charts/supabase/templates/studio/deployment.yaml
@@ -67,12 +67,6 @@ spec:
               containerPort: 3000
               protocol: TCP
           env:
-            {{- range $key, $value := .Values.environment.studio }}
-            {{- if and (ne $key "POSTGRES_HOST") (ne $key "POSTGRES_PORT") }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
-            {{- end }}
-            {{- end }}
             {{- if .Values.deployment.kong.enabled }}
             - name: SUPABASE_URL
               value: http://{{ include "supabase.kong.fullname" . }}:{{ .Values.service.kong.port }}
@@ -85,7 +79,6 @@ spec:
             {{- include "supabase.db.hostEnv" (dict "root" . "name" "POSTGRES_HOST") | nindent 12 }}
             {{- include "supabase.db.portEnv" (dict "root" . "name" "POSTGRES_PORT") | nindent 12 }}
 
-            {{- if not (hasKey (default (dict) .Values.environment.studio) "POSTGRES_DB") }}
             - name: POSTGRES_DB
               {{- if and .Values.secret.db.secretRef (not (hasKey (default (dict) .Values.secret.db.secretRefKey) "database")) }}
               value: {{ .Values.secret.db.database | default "postgres" | quote }}
@@ -95,7 +88,6 @@ spec:
                   name: {{ include "supabase.secret.db.name" . }}
                   key: {{ include "supabase.secret.db.key.database" . }}
               {{- end }}
-            {{- end }}
 
             - name: POSTGRES_PASSWORD
               valueFrom:
@@ -156,6 +148,7 @@ spec:
             - name: SNIPPETS_MANAGEMENT_FOLDER
               value: /app/snippets
             {{- end }}
+            {{- include "supabase.env.render" (dict "env" .Values.environment.studio) | nindent 12 }}
           {{- with .Values.deployment.studio.envFrom }}
           envFrom:
             {{- toYaml . | nindent 12 }}

--- a/charts/supabase/templates/vector/deployment.yaml
+++ b/charts/supabase/templates/vector/deployment.yaml
@@ -67,10 +67,6 @@ spec:
             - containerPort: {{ .Values.service.vector.port }}
               protocol: TCP
           env:
-            {{- range $key, $value := .Values.environment.vector }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
-            {{- end }}
             - name: VECTOR_SELF_NODE_NAME
               valueFrom:
                 fieldRef:
@@ -82,6 +78,7 @@ spec:
                   name: {{ include "supabase.secret.analytics.name" . }}
                   key: {{ include "supabase.secret.analytics.key.publicAccessToken" . }}
             {{- end }}
+            {{- include "supabase.env.render" (dict "env" .Values.environment.vector) | nindent 12 }}
           {{- with .Values.deployment.vector.envFrom }}
           envFrom:
             {{- toYaml . | nindent 12 }}

--- a/charts/supabase/values.yaml
+++ b/charts/supabase/values.yaml
@@ -670,12 +670,6 @@ environment:
   analytics:
     - name: LOGFLARE_NODE_HOST
       value: 127.0.0.1
-    - name: DB_USERNAME
-      value: supabase_admin
-    - name: DB_DATABASE
-      value: _supabase
-    - name: DB_DRIVER
-      value: postgresql
     - name: DB_SCHEMA
       value: _analytics
     - name: POSTGRES_BACKEND_SCHEMA
@@ -688,13 +682,6 @@ environment:
       value: multibackend=true
 
   auth:
-    - name: DB_USER
-      value: supabase_auth_admin
-    - name: DB_DRIVER
-      value: postgres
-    ## SSL mode options: disable, allow, prefer, require, verify-ca, verify-full
-    - name: DB_SSL
-      value: disable
     - name: API_EXTERNAL_URL
       value: http://supabase.local
     - name: GOTRUE_API_HOST
@@ -819,13 +806,6 @@ environment:
     #       key: <secret-key>
 
   functions:
-    - name: DB_USERNAME
-      value: postgres
-    - name: DB_DRIVER
-      value: postgresql
-    ## SSL mode options: disable, allow, prefer, require, verify-ca, verify-full
-    - name: DB_SSL
-      value: disable
     - name: VERIFY_JWT
       value: false
 
@@ -861,13 +841,8 @@ environment:
       value: "2"
 
   meta:
-    - name: DB_USER
-      value: supabase_admin
     - name: DB_DRIVER
       value: postgres
-    ## SSL mode options: disable, allow, prefer, require, verify-ca, verify-full
-    - name: DB_SSL
-      value: disable
     - name: PG_META_PORT
       value: "8080"
 
@@ -904,13 +879,6 @@ environment:
       value: true
 
   rest:
-    - name: DB_USER
-      value: authenticator
-    - name: DB_DRIVER
-      value: postgres
-    ## SSL mode options: disable, allow, prefer, require, verify-ca, verify-full
-    - name: DB_SSL
-      value: disable
     - name: PGRST_DB_SCHEMAS
       value: public,storage,graphql_public
     - name: PGRST_DB_ANON_ROLE
@@ -921,13 +889,6 @@ environment:
       value: 3600
 
   storage:
-    - name: DB_USER
-      value: supabase_storage_admin
-    - name: DB_DRIVER
-      value: postgres
-    ## SSL mode options: disable, allow, prefer, require, verify-ca, verify-full
-    - name: DB_SSL
-      value: disable
     - name: REQUEST_ALLOW_X_FORWARDED_PATH
       value: "true"
     - name: FILE_SIZE_LIMIT

--- a/charts/supabase/values.yaml
+++ b/charts/supabase/values.yaml
@@ -668,158 +668,302 @@ image:
 
 environment:
   analytics:
-    LOGFLARE_NODE_HOST: 127.0.0.1
-    DB_USERNAME: supabase_admin
-    DB_DATABASE: _supabase
-    DB_DRIVER: postgresql
-    DB_SCHEMA: _analytics
-    POSTGRES_BACKEND_SCHEMA: _analytics
-    LOGFLARE_SINGLE_TENANT: "true"
-    LOGFLARE_SUPABASE_MODE: "true"
-    LOGFLARE_FEATURE_FLAG_OVERRIDE: multibackend=true
+    - name: LOGFLARE_NODE_HOST
+      value: 127.0.0.1
+    - name: DB_USERNAME
+      value: supabase_admin
+    - name: DB_DATABASE
+      value: _supabase
+    - name: DB_DRIVER
+      value: postgresql
+    - name: DB_SCHEMA
+      value: _analytics
+    - name: POSTGRES_BACKEND_SCHEMA
+      value: _analytics
+    - name: LOGFLARE_SINGLE_TENANT
+      value: "true"
+    - name: LOGFLARE_SUPABASE_MODE
+      value: "true"
+    - name: LOGFLARE_FEATURE_FLAG_OVERRIDE
+      value: multibackend=true
 
   auth:
-    DB_USER: supabase_auth_admin
-    DB_DRIVER: postgres
+    - name: DB_USER
+      value: supabase_auth_admin
+    - name: DB_DRIVER
+      value: postgres
     ## SSL mode options: disable, allow, prefer, require, verify-ca, verify-full
-    DB_SSL: disable
-    API_EXTERNAL_URL: http://supabase.local
-    GOTRUE_API_HOST: "0.0.0.0"
-    GOTRUE_API_PORT: "9999"
-    GOTRUE_SITE_URL: http://supabase.local
-    GOTRUE_URI_ALLOW_LIST: "*"
-    GOTRUE_DISABLE_SIGNUP: "false"
-    GOTRUE_JWT_DEFAULT_GROUP_NAME: authenticated
-    GOTRUE_JWT_ADMIN_ROLES: service_role
-    GOTRUE_JWT_AUD: authenticated
-    GOTRUE_JWT_EXP: "3600"
-    GOTRUE_EXTERNAL_EMAIL_ENABLED: "true"
-    GOTRUE_MAILER_AUTOCONFIRM: "true"
-    GOTRUE_EXTERNAL_ANONYMOUS_USERS_ENABLED: "false"
-    # GOTRUE_MAILER_SECURE_EMAIL_CHANGE_ENABLED: true
-    # GOTRUE_SMTP_MAX_FREQUENCY: 1s
-    GOTRUE_SMTP_ADMIN_EMAIL: "SMTP_ADMIN_MAIL"
-    GOTRUE_SMTP_HOST: "SMTP_HOST"
-    GOTRUE_SMTP_PORT: "123"
-    GOTRUE_EXTERNAL_PHONE_ENABLED: "false"
-    GOTRUE_SMS_AUTOCONFIRM: "false"
-    GOTRUE_SMTP_SENDER_NAME: "SMTP_SENDER_NAME"
-    GOTRUE_MAILER_URLPATHS_INVITE: "/auth/v1/verify"
-    GOTRUE_MAILER_URLPATHS_CONFIRMATION: "/auth/v1/verify"
-    GOTRUE_MAILER_URLPATHS_RECOVERY: "/auth/v1/verify"
-    GOTRUE_MAILER_URLPATHS_EMAIL_CHANGE: "/auth/v1/verify"
+    - name: DB_SSL
+      value: disable
+    - name: API_EXTERNAL_URL
+      value: http://supabase.local
+    - name: GOTRUE_API_HOST
+      value: "0.0.0.0"
+    - name: GOTRUE_API_PORT
+      value: "9999"
+    - name: GOTRUE_SITE_URL
+      value: http://supabase.local
+    - name: GOTRUE_URI_ALLOW_LIST
+      value: "*"
+    - name: GOTRUE_DISABLE_SIGNUP
+      value: "false"
+    - name: GOTRUE_JWT_DEFAULT_GROUP_NAME
+      value: authenticated
+    - name: GOTRUE_JWT_ADMIN_ROLES
+      value: service_role
+    - name: GOTRUE_JWT_AUD
+      value: authenticated
+    - name: GOTRUE_JWT_EXP
+      value: "3600"
+    - name: GOTRUE_EXTERNAL_EMAIL_ENABLED
+      value: "true"
+    - name: GOTRUE_MAILER_AUTOCONFIRM
+      value: "true"
+    - name: GOTRUE_EXTERNAL_ANONYMOUS_USERS_ENABLED
+      value: "false"
+    # - name: GOTRUE_MAILER_SECURE_EMAIL_CHANGE_ENABLED
+    #   value: true
+    # - name: GOTRUE_SMTP_MAX_FREQUENCY
+    #   value: 1s
+    - name: GOTRUE_SMTP_ADMIN_EMAIL
+      value: "SMTP_ADMIN_MAIL"
+    - name: GOTRUE_SMTP_HOST
+      value: "SMTP_HOST"
+    - name: GOTRUE_SMTP_PORT
+      value: "123"
+    - name: GOTRUE_EXTERNAL_PHONE_ENABLED
+      value: "false"
+    - name: GOTRUE_SMS_AUTOCONFIRM
+      value: "false"
+    - name: GOTRUE_SMTP_SENDER_NAME
+      value: "SMTP_SENDER_NAME"
+    - name: GOTRUE_MAILER_URLPATHS_INVITE
+      value: "/auth/v1/verify"
+    - name: GOTRUE_MAILER_URLPATHS_CONFIRMATION
+      value: "/auth/v1/verify"
+    - name: GOTRUE_MAILER_URLPATHS_RECOVERY
+      value: "/auth/v1/verify"
+    - name: GOTRUE_MAILER_URLPATHS_EMAIL_CHANGE
+      value: "/auth/v1/verify"
     ## Uncomment to enable custom access token hook. Please see: https://supabase.com/docs/guides/auth/auth-hooks
     ## for full list of hooks and additional details about custom_access_token_hook
-    # GOTRUE_HOOK_CUSTOM_ACCESS_TOKEN_ENABLED: "true"
-    # GOTRUE_HOOK_CUSTOM_ACCESS_TOKEN_URI: "pg-functions://postgres/public/custom_access_token_hook"
-    # GOTRUE_HOOK_CUSTOM_ACCESS_TOKEN_SECRETS: "<standard-base64-secret>"
-    # GOTRUE_HOOK_MFA_VERIFICATION_ATTEMPT_ENABLED: "true"
-    # GOTRUE_HOOK_MFA_VERIFICATION_ATTEMPT_URI: "pg-functions://postgres/public/mfa_verification_attempt"
-    # GOTRUE_HOOK_PASSWORD_VERIFICATION_ATTEMPT_ENABLED: "true"
-    # GOTRUE_HOOK_PASSWORD_VERIFICATION_ATTEMPT_URI: "pg-functions://postgres/public/password_verification_attempt"
-    # GOTRUE_HOOK_SEND_SMS_ENABLED: "false"
-    # GOTRUE_HOOK_SEND_SMS_URI: "pg-functions://postgres/public/custom_access_token_hook"
-    # GOTRUE_HOOK_SEND_SMS_SECRETS: "v1,whsec_VGhpcyBpcyBhbiBleGFtcGxlIG9mIGEgc2hvcnRlciBCYXNlNjQgc3RyaW5n"
-    # GOTRUE_HOOK_SEND_EMAIL_ENABLED: "false"
-    # GOTRUE_HOOK_SEND_EMAIL_URI: "http://host.docker.internal:54321/functions/v1/email_sender"
-    # GOTRUE_HOOK_SEND_EMAIL_SECRETS: "v1,whsec_VGhpcyBpcyBhbiBleGFtcGxlIG9mIGEgc2hvcnRlciBCYXNlNjQgc3RyaW5n"
+    # - name: GOTRUE_HOOK_CUSTOM_ACCESS_TOKEN_ENABLED
+    #   valueFrom:
+    #     secretKeyRef:
+    #       name: <secret-name>
+    #       key: <secret-key>
+    # - name: GOTRUE_HOOK_CUSTOM_ACCESS_TOKEN_URI
+    #   valueFrom:
+    #     secretKeyRef:
+    #       name: <secret-name>
+    #       key: <secret-key>
+    # - name: GOTRUE_HOOK_CUSTOM_ACCESS_TOKEN_SECRETS
+    #   valueFrom:
+    #     secretKeyRef:
+    #       name: <secret-name>
+    #       key: <secret-key>
+    # - name: GOTRUE_HOOK_MFA_VERIFICATION_ATTEMPT_ENABLED
+    #   value: "true"
+    # - name: GOTRUE_HOOK_MFA_VERIFICATION_ATTEMPT_URI
+    #   value: "pg-functions://postgres/public/mfa_verification_attempt"
+    # - name: GOTRUE_HOOK_PASSWORD_VERIFICATION_ATTEMPT_ENABLED
+    #   valueFrom:
+    #     secretKeyRef:
+    #       name: <secret-name>
+    #       key: <secret-key>
+    # - name: GOTRUE_HOOK_PASSWORD_VERIFICATION_ATTEMPT_URI
+    #   valueFrom:
+    #     secretKeyRef:
+    #       name: <secret-name>
+    #       key: <secret-key>
+    # - name: GOTRUE_HOOK_SEND_SMS_ENABLED
+    #   value: "false"
+    # - name: GOTRUE_HOOK_SEND_SMS_URI
+    #   valueFrom:
+    #     secretKeyRef:
+    #       name: <secret-name>
+    #       key: <secret-key>
+    # - name: GOTRUE_HOOK_SEND_SMS_SECRETS
+    #   valueFrom:
+    #     secretKeyRef:
+    #       name: <secret-name>
+    #       key: <secret-key>
+    # - name: GOTRUE_HOOK_SEND_EMAIL_ENABLED
+    #   value: "false"
+    # - name: GOTRUE_HOOK_SEND_EMAIL_URI
+    #   value: "http://host.docker.internal:54321/functions/v1/email_sender"
+    # - name: GOTRUE_HOOK_SEND_EMAIL_SECRETS
+    #   valueFrom:
+    #     secretKeyRef:
+    #       name: <secret-name>
+    #       key: <secret-key>
 
   db:
-    POSTGRES_HOST: /var/run/postgresql
-    PGPORT: "5432"
-    POSTGRES_PORT: "5432"
-    JWT_EXP: 3600
-    # POSTGRES_HOST_AUTH_METHOD: md5
+    - name: POSTGRES_HOST
+      value: /var/run/postgresql
+    - name: PGPORT
+      value: "5432"
+    - name: POSTGRES_PORT
+      value: "5432"
+    - name: JWT_EXP
+      value: 3600
+    # - name: POSTGRES_HOST_AUTH_METHOD
+    #   value: md5
     ## Enable SSL for postgres by specifying paths for mounted certificate key pair
-    # POSTGRES_SSL_CERT: /path/to/ssl/server.crt
-    # POSTGRES_SSL_KEY: /path/to/ssl/server.key
+    # - name: POSTGRES_SSL_CERT
+    #   value: /path/to/ssl/server.crt
+    # - name: POSTGRES_SSL_KEY
+    #   valueFrom:
+    #     secretKeyRef:
+    #       name: <secret-name>
+    #       key: <secret-key>
 
   functions:
-    DB_USERNAME: postgres
-    DB_DRIVER: postgresql
+    - name: DB_USERNAME
+      value: postgres
+    - name: DB_DRIVER
+      value: postgresql
     ## SSL mode options: disable, allow, prefer, require, verify-ca, verify-full
-    DB_SSL: disable
-    VERIFY_JWT: false
+    - name: DB_SSL
+      value: disable
+    - name: VERIFY_JWT
+      value: false
 
   imgproxy:
-    IMGPROXY_BIND: ":5001"
-    IMGPROXY_LOCAL_FILESYSTEM_ROOT: /
-    IMGPROXY_USE_ETAG: "true"
-    IMGPROXY_ENABLE_WEBP_DETECTION: "true"
+    - name: IMGPROXY_BIND
+      value: ":5001"
+    - name: IMGPROXY_LOCAL_FILESYSTEM_ROOT
+      value: /
+    - name: IMGPROXY_USE_ETAG
+      value: "true"
+    - name: IMGPROXY_ENABLE_WEBP_DETECTION
+      value: "true"
 
   kong:
-    KONG_DATABASE: "off"
-    KONG_DECLARATIVE_CONFIG: /usr/local/kong/kong.yml
+    - name: KONG_DATABASE
+      value: "off"
+    - name: KONG_DECLARATIVE_CONFIG
+      value: /usr/local/kong/kong.yml
     ## https://github.com/supabase/cli/issues/14
-    KONG_DNS_ORDER: LAST,A,CNAME
-    KONG_PLUGINS: request-transformer,cors,key-auth,acl,basic-auth,post-function
-    KONG_NGINX_PROXY_PROXY_BUFFER_SIZE: 160k
-    KONG_NGINX_PROXY_PROXY_BUFFERS: 64 160k
-    KONG_LOG_LEVEL: warn
+    - name: KONG_DNS_ORDER
+      value: LAST,A,CNAME
+    - name: KONG_PLUGINS
+      value: request-transformer,cors,key-auth,acl,basic-auth,post-function
+    - name: KONG_NGINX_PROXY_PROXY_BUFFER_SIZE
+      value: 160k
+    - name: KONG_NGINX_PROXY_PROXY_BUFFERS
+      value: 64 160k
+    - name: KONG_LOG_LEVEL
+      value: warn
 
     # Please see: https://github.com/supabase-community/supabase-kubernetes/issues/187
-    KONG_NGINX_WORKER_PROCESSES: "2"
+    - name: KONG_NGINX_WORKER_PROCESSES
+      value: "2"
 
   meta:
-    DB_USER: supabase_admin
-    DB_DRIVER: postgres
+    - name: DB_USER
+      value: supabase_admin
+    - name: DB_DRIVER
+      value: postgres
     ## SSL mode options: disable, allow, prefer, require, verify-ca, verify-full
-    DB_SSL: disable
-    PG_META_PORT: "8080"
+    - name: DB_SSL
+      value: disable
+    - name: PG_META_PORT
+      value: "8080"
 
-  minio: {}
+  minio:
+    []
 
   realtime:
-    DB_USER: supabase_admin
+    - name: DB_USER
+      value: supabase_admin
     ## Set to true to enforce TLS connections to Postgres
-    DB_SSL: false
-    PORT: "4000"
-    FLY_ALLOC_ID: fly123
-    FLY_APP_NAME: realtime
-    ENABLE_TAILSCALE: "false"
-    DB_AFTER_CONNECT_QUERY: "SET search_path TO _realtime"
-    ERL_AFLAGS: -proto_dist inet_tcp
-    DNS_NODES: "''"
-    RLIMIT_NOFILE: "10000"
-    APP_NAME: realtime
-    SEED_SELF_HOST: true
-    RUN_JANITOR: true
+    - name: DB_SSL
+      value: false
+    - name: PORT
+      value: "4000"
+    - name: FLY_ALLOC_ID
+      value: fly123
+    - name: FLY_APP_NAME
+      value: realtime
+    - name: ENABLE_TAILSCALE
+      value: "false"
+    - name: DB_AFTER_CONNECT_QUERY
+      value: "SET search_path TO _realtime"
+    - name: ERL_AFLAGS
+      value: -proto_dist inet_tcp
+    - name: DNS_NODES
+      value: "''"
+    - name: RLIMIT_NOFILE
+      value: "10000"
+    - name: APP_NAME
+      value: realtime
+    - name: SEED_SELF_HOST
+      value: true
+    - name: RUN_JANITOR
+      value: true
 
   rest:
-    DB_USER: authenticator
-    DB_DRIVER: postgres
+    - name: DB_USER
+      value: authenticator
+    - name: DB_DRIVER
+      value: postgres
     ## SSL mode options: disable, allow, prefer, require, verify-ca, verify-full
-    DB_SSL: disable
-    PGRST_DB_SCHEMAS: public,storage,graphql_public
-    PGRST_DB_ANON_ROLE: anon
-    PGRST_DB_USE_LEGACY_GUCS: false
-    PGRST_APP_SETTINGS_JWT_EXP: 3600
+    - name: DB_SSL
+      value: disable
+    - name: PGRST_DB_SCHEMAS
+      value: public,storage,graphql_public
+    - name: PGRST_DB_ANON_ROLE
+      value: anon
+    - name: PGRST_DB_USE_LEGACY_GUCS
+      value: false
+    - name: PGRST_APP_SETTINGS_JWT_EXP
+      value: 3600
 
   storage:
-    DB_USER: supabase_storage_admin
-    DB_DRIVER: postgres
+    - name: DB_USER
+      value: supabase_storage_admin
+    - name: DB_DRIVER
+      value: postgres
     ## SSL mode options: disable, allow, prefer, require, verify-ca, verify-full
-    DB_SSL: disable
-    REQUEST_ALLOW_X_FORWARDED_PATH: "true"
-    FILE_SIZE_LIMIT: "52428800"
-    FILE_STORAGE_BACKEND_PATH: /var/lib/storage
-    TENANT_ID: stub
-    REGION: stub
-    GLOBAL_S3_BUCKET: stub
-    ENABLE_IMAGE_TRANSFORMATION: "true"
+    - name: DB_SSL
+      value: disable
+    - name: REQUEST_ALLOW_X_FORWARDED_PATH
+      value: "true"
+    - name: FILE_SIZE_LIMIT
+      value: "52428800"
+    - name: FILE_STORAGE_BACKEND_PATH
+      value: /var/lib/storage
+    - name: TENANT_ID
+      value: stub
+    - name: REGION
+      value: stub
+    - name: GLOBAL_S3_BUCKET
+      value: stub
+    - name: ENABLE_IMAGE_TRANSFORMATION
+      value: "true"
 
   studio:
-    HOSTNAME: "::"
-    STUDIO_PORT: "3000"
-    POSTGRES_PORT: 5432
-    DEFAULT_ORGANIZATION_NAME: Default Organization
-    DEFAULT_PROJECT_NAME: Default Project
-    SUPABASE_PUBLIC_URL: http://supabase.local
-    NEXT_PUBLIC_ENABLE_LOGS: true
+    - name: HOSTNAME
+      value: "::"
+    - name: STUDIO_PORT
+      value: "3000"
+    - name: POSTGRES_PORT
+      value: 5432
+    - name: DEFAULT_ORGANIZATION_NAME
+      value: Default Organization
+    - name: DEFAULT_PROJECT_NAME
+      value: Default Project
+    - name: SUPABASE_PUBLIC_URL
+      value: http://supabase.local
+    - name: NEXT_PUBLIC_ENABLE_LOGS
+      value: true
     ## Set value to bigquery to use Big Query backend for analytics (postgres or bigquery)
-    NEXT_ANALYTICS_BACKEND_PROVIDER: postgres
+    - name: NEXT_ANALYTICS_BACKEND_PROVIDER
+      value: postgres
 
-  vector: {}
+  vector:
+    []
 
 persistence:
   db:


### PR DESCRIPTION
Closes #200
Re-implements #201

## What kind of change does this PR introduce?

Feature (breaking change).

## What is the current behavior?

`environment.<component>` only accepts plain string values, so there is no way to inject a named env var via `valueFrom` (e.g. an OAuth provider secret from a `Secret` key). The issue #200 asked for this, and #201 proposed adding a separate `deployment.<component>.extraEnv` block.

## What is the new behavior?

Instead of adding a separate `extraEnv` block, this PR changes the existing `environment.<component>` value from a plain-value map to a first-class Kubernetes `env` array. Each entry supports both `value` and `valueFrom` (secretKeyRef, configMapKeyRef, fieldRef, etc.).

```yaml
# Before
environment:
  auth:
    GOTRUE_API_HOST: "0.0.0.0"

# After
environment:
  auth:
    - name: GOTRUE_API_HOST
      value: "0.0.0.0"
    - name: GOTRUE_EXTERNAL_AZURE_SECRET
      valueFrom:
        secretKeyRef:
          name: azure-secret
          key: secret
```

## Breaking change

`environment.<component>` is no longer a map of key/value pairs. Existing overrides must be migrated to the array format shown above.

## Design decisions

- Chart-managed env defaults are rendered first.
- The user-provided `environment.<component>` array is rendered last, so it can override any chart-managed env var.
- `DB_DRIVER`, `DB_USER`/`DB_USERNAME`, `DB_SSL`, and `DB_DATABASE` are hardcoded as chart defaults because they are referenced via `$(...)` in connection URLs and must be defined before those URLs.
- `environment.minio` is now also rendered in the MinIO deployment, so extra env vars can be added to it as well.

## Validation

- `helm lint` ✅
- `helm template` with default values ✅
- `helm template` with `ci/example.yaml` ✅
- `helm install --dry-run=server` ✅
- Runtime test on a kind cluster: all pods come up correctly ✅
