### PR TITLE
feat(realtime): expose commmand and args

### DIFF
--- a/charts/supabase/templates/realtime/deployment.yaml
+++ b/charts/supabase/templates/realtime/deployment.yaml
@@ -85,8 +85,18 @@ spec:
         - name: {{ include "supabase.realtime.name" $ }}
           image: "{{ .Values.image.realtime.repository }}:{{ .Values.image.realtime.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.realtime.pullPolicy }}
-          command: ["/bin/sh"]
-          args: ["-c", "/app/bin/migrate && /app/bin/realtime eval 'Realtime.Release.seeds(Realtime.Repo)' && /app/bin/server"]
+          {{- with .Values.deployment.realtime.command }}
+          command:
+            {{- range . }}
+            - {{ . | quote }}
+            {{- end }}
+          {{- end }}
+          {{- with .Values.deployment.realtime.args }}
+          args: 
+            {{- range . }}
+            - {{ . | quote }}
+            {{- end }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 4000

--- a/charts/supabase/values.yaml
+++ b/charts/supabase/values.yaml
@@ -452,6 +452,8 @@ deployment:
     priorityClassName: ""
     dnsPolicy: ""
     dnsConfig: {}
+    command: ["/bin/sh"]
+    args: ["-c", "/app/bin/migrate && /app/bin/realtime eval 'Realtime.Release.seeds(Realtime.Repo)' && /app/bin/server"]
     envFrom: []
     livenessProbe: {}
     readinessProbe: {}

--- a/charts/supabase/values.yaml
+++ b/charts/supabase/values.yaml
@@ -452,8 +452,8 @@ deployment:
     priorityClassName: ""
     dnsPolicy: ""
     dnsConfig: {}
-    command: ["/bin/sh"]
-    args: ["-c", "/app/bin/migrate && /app/bin/realtime eval 'Realtime.Release.seeds(Realtime.Repo)' && /app/bin/server"]
+    command: []
+    args: []
     envFrom: []
     livenessProbe: {}
     readinessProbe: {}


### PR DESCRIPTION
## What kind of change does this PR introduce?

**Feature**

Expose `deployment.realtime.command` and `deployment.realtime.args`

## What is the current behavior?

Currently the command and args are hard-coded in the template:

```yaml
command: ["/bin/sh"]
args: ["-c", "/app/bin/migrate && /app/bin/realtime eval 'Realtime.Release.seeds(Realtime.Repo)' && /app/bin/server"]
```

The `/app/bin/realtime eval 'Realtime.Release.seeds(Realtime.Repo)'` command forces the self-host seeds to run even if `SEED_SELF_HOST` is false.

This PR is an alternative to https://github.com/supabase-community/supabase-kubernetes/pull/207

## What is the new behavior?

The template now renders the command and args from chart values (which default to the previously hard-coded values for backward compatibility).

## Additional context

I kept the default values out of an abundance of caution but a little digging revealed that they may be surplus to requirements.

The [Dockerfile](https://github.com/supabase/realtime/blob/v2.102.3/Dockerfile) sets the default command to `/app/bin/server` with  `/app/run.sh` as the entrypoint. 

The [run.sh](https://github.com/supabase/realtime/blob/v2.102.3/run.sh) script:
- Runs `/app/bin/migrate`
- Conditionally runs `/app/bin/realtime eval 'Realtime.Release.seeds(Realtime.Repo)'` if `SEED_SELF_HOST` is true
- Runs the command (default `/app/bin/server`) via `exec "$@"`

This makes the current chart command/args redundant and actually causes migrations (and potentially seeds) to run twice (admittedly, the second migration run would be a harmless no-op).

In the future it may be more sensible to default to empty arrays:

```yaml
command: []
args: []
```
