### PR TITLE
feat(chart): disable analytics and vector by default and fix Studio env var warning

### DIFF
--- a/charts/supabase/README.md
+++ b/charts/supabase/README.md
@@ -41,7 +41,6 @@ The database configuration we provide is an example using only one master. If yo
     kubectl get pod -l app.kubernetes.io/instance=demo
     
     NAME                                      READY   STATUS    RESTARTS      AGE
-    demo-supabase-analytics-xxxxxxxxxx-xxxxx  1/1     Running   0             47s
     demo-supabase-auth-xxxxxxxxxx-xxxxx       1/1     Running   0             47s
     demo-supabase-db-0-xxxxxxxxxx-xxxxx       1/1     Running   0             47s
     demo-supabase-functions-xxxxxxxxxx-xxxxx  1/1     Running   0             47s
@@ -52,8 +51,10 @@ The database configuration we provide is an example using only one master. If yo
     demo-supabase-rest-xxxxxxxxxx-xxxxx       1/1     Running   0             47s
     demo-supabase-storage-xxxxxxxxxx-xxxxx    1/1     Running   0             47s
     demo-supabase-studio-xxxxxxxxxx-xxxxx     1/1     Running   0             47s
-    demo-supabase-vector-xxxxxxxxxx-xxxxx     1/1     Running   0             47s
     ```
+
+    > **Note:** `analytics` (Logflare) and `vector` are disabled by default.
+    > To enable the Logs section in Studio, set both `deployment.analytics.enabled=true` and `deployment.vector.enabled=true`.
 
 5. Open Supabase Studio in your browser: http://supabase.local
 
@@ -136,6 +137,8 @@ secret:
 ```
 
 ### Analytics secret
+
+Analytics/Vector (logs) are **disabled by default**. To enable the Logs feature in Studio, set both `deployment.analytics.enabled=true` and `deployment.vector.enabled=true`.
 
 A new logflare secret API key is required for securing communication between all of the Supabase services. To set the secret, generate a new 32 characters long secret similar to the step [above](#jwt-secret).
 

--- a/charts/supabase/templates/_helpers.tpl
+++ b/charts/supabase/templates/_helpers.tpl
@@ -62,6 +62,13 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+Return true if the logging stack (analytics + vector) is enabled.
+*/}}
+{{- define "supabase.logs.enabled" -}}
+{{- and .Values.deployment.analytics.enabled .Values.deployment.vector.enabled | ternary "true" "false" -}}
+{{- end -}}
+
+{{/*
 Render environment variables from a list of { name, value | valueFrom } entries.
 All plain values are forced to strings so Kubernetes accepts them.
 */}}

--- a/charts/supabase/templates/studio/deployment.yaml
+++ b/charts/supabase/templates/studio/deployment.yaml
@@ -129,11 +129,6 @@ spec:
             {{- if eq (include "supabase.logs.enabled" .) "true" }}
             - name: LOGFLARE_URL
               value: http://{{ include "supabase.analytics.fullname" . }}:{{ .Values.service.analytics.port }}
-            - name:  LOGFLARE_PUBLIC_ACCESS_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "supabase.secret.analytics.name" . }}
-                  key: {{ include "supabase.secret.analytics.key.publicAccessToken" . }}
             - name: LOGFLARE_PRIVATE_ACCESS_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/charts/supabase/templates/studio/deployment.yaml
+++ b/charts/supabase/templates/studio/deployment.yaml
@@ -126,7 +126,7 @@ spec:
                   name: {{ include "supabase.secret.jwt.name" . }}
                   key: {{ include "supabase.secret.jwt.key.secret" . }}
 
-            {{- if .Values.deployment.analytics.enabled }}
+            {{- if eq (include "supabase.logs.enabled" .) "true" }}
             - name: LOGFLARE_URL
               value: http://{{ include "supabase.analytics.fullname" . }}:{{ .Values.service.analytics.port }}
             - name:  LOGFLARE_PUBLIC_ACCESS_TOKEN
@@ -140,6 +140,8 @@ spec:
                   name: {{ include "supabase.secret.analytics.name" . }}
                   key: {{ include "supabase.secret.analytics.key.privateAccessToken" . }}
             {{- end }}
+            - name: ENABLED_FEATURES_LOGS_ALL
+              value: {{ include "supabase.logs.enabled" . | quote }}
             {{- if .Values.persistence.functions.enabled }}
             - name: EDGE_FUNCTIONS_MANAGEMENT_FOLDER
               value: /home/deno/functions

--- a/charts/supabase/values.yaml
+++ b/charts/supabase/values.yaml
@@ -229,7 +229,7 @@ secret:
 
 deployment:
   analytics:
-    enabled: true
+    enabled: false
     replicaCount: 1
     nameOverride: ""
     fullnameOverride: ""
@@ -555,7 +555,7 @@ deployment:
     strategy: {}
 
   vector:
-    enabled: true
+    enabled: false
     replicaCount: 1
     nameOverride: ""
     fullnameOverride: ""
@@ -919,8 +919,6 @@ environment:
       value: Default Project
     - name: SUPABASE_PUBLIC_URL
       value: http://supabase.local
-    - name: NEXT_PUBLIC_ENABLE_LOGS
-      value: true
     ## Set value to bigquery to use Big Query backend for analytics (postgres or bigquery)
     - name: NEXT_ANALYTICS_BACKEND_PROVIDER
       value: postgres

--- a/charts/supabase/values.yaml
+++ b/charts/supabase/values.yaml
@@ -911,8 +911,6 @@ environment:
       value: "::"
     - name: STUDIO_PORT
       value: "3000"
-    - name: POSTGRES_PORT
-      value: 5432
     - name: DEFAULT_ORGANIZATION_NAME
       value: Default Organization
     - name: DEFAULT_PROJECT_NAME


### PR DESCRIPTION
This PR changes the default logs stack behavior to match the upstream Docker Compose setup.

- Disable `analytics` (Logflare) and `vector` deployments by default.
- Add `ENABLED_FEATURES_LOGS_ALL` to Studio:
  - `"false"` by default
  - `"true"` when both `analytics` and `vector` are enabled
- Conditionally inject `LOGFLARE_URL` and `LOGFLARE_PRIVATE_ACCESS_TOKEN` into Studio only when the logs stack is active.
- Remove the duplicate `POSTGRES_PORT` entry from `environment.studio`, which was causing the Kubernetes warning about hiding a previous env var definition.
- Update `README.md` to document that logs are disabled by default and how to enable them.