### PR TITLE
fix: generate API keys with 5-year expiry instead of JWTExpSec

### DIFF
--- a/internal/project/jwt_secret.go
+++ b/internal/project/jwt_secret.go
@@ -30,6 +30,11 @@ import (
 )
 
 const (
+	// DefaultAPIKeyExpiry is the lifetime used for static API keys such as
+	// ANON_KEY and SERVICE_ROLE_KEY. It matches the 5-year expiry used by the
+	// Supabase self-hosted generate-keys.sh script.
+	DefaultAPIKeyExpiry = 5 * 365 * 24 * time.Hour
+
 	// JWTSecretKey is the Secret data key that holds the symmetric JWT secret.
 	JWTSecretKey = "jwt-secret"
 
@@ -78,14 +83,14 @@ func JWTSecret(project *supabasev1alpha1.Project) (*corev1.Secret, error) {
 	jwtSecret := base64.StdEncoding.EncodeToString(jwtSecretBytes)
 
 	now := time.Now()
-	jwtExpiry := time.Duration(*project.Spec.JWTExpSec) * time.Second
+	apiKeyExpiry := DefaultAPIKeyExpiry
 
-	anonKey, err := helper.GenerateJWTToken(jwtSecret, "anon", now, jwtExpiry)
+	anonKey, err := helper.GenerateJWTToken(jwtSecret, "anon", now, apiKeyExpiry)
 	if err != nil {
 		return nil, fmt.Errorf("generating anon key: %w", err)
 	}
 
-	serviceKey, err := helper.GenerateJWTToken(jwtSecret, "service_role", now, jwtExpiry)
+	serviceKey, err := helper.GenerateJWTToken(jwtSecret, "service_role", now, apiKeyExpiry)
 	if err != nil {
 		return nil, fmt.Errorf("generating service key: %w", err)
 	}
@@ -114,12 +119,12 @@ func JWTSecret(project *supabasev1alpha1.Project) (*corev1.Secret, error) {
 		return nil, fmt.Errorf("building JWT JWKS: %w", err)
 	}
 
-	anonKeyAsym, err := helper.SignES256JWT(ecKey, kid, "anon", now, jwtExpiry)
+	anonKeyAsym, err := helper.SignES256JWT(ecKey, kid, "anon", now, apiKeyExpiry)
 	if err != nil {
 		return nil, fmt.Errorf("generating asymmetric anon key: %w", err)
 	}
 
-	serviceKeyAsym, err := helper.SignES256JWT(ecKey, kid, "service_role", now, jwtExpiry)
+	serviceKeyAsym, err := helper.SignES256JWT(ecKey, kid, "service_role", now, apiKeyExpiry)
 	if err != nil {
 		return nil, fmt.Errorf("generating asymmetric service key: %w", err)
 	}


### PR DESCRIPTION
## Problem

`ANON_KEY`, `SERVICE_ROLE_KEY`, and their asymmetric variants were being generated with `spec.jwtExpSec` as their JWT expiration time. The default value of `jwtExpSec` is `3600` seconds (1 hour), so the API keys expired shortly after project creation.

Once the token expired, any internal probe or service using `Authorization: Bearer ${ANON_KEY}` started receiving HTTP 403 responses. The Realtime component was particularly affected, showing:

```
Startup probe failed: curl: (22) The requested URL returned error: 403
```

This matches the behavior reported in the Supabase self-hosted setup, where `ANON_KEY` and `SERVICE_ROLE_KEY` are generated with a 5-year lifetime, while `JWT_EXPIRY` is only used to configure `app.settings.jwt_exp` in Postgres.

## What changed

- Added `DefaultAPIKeyExpiry` constant (`5 * 365 * 24 * time.Hour`).
- `ANON_KEY`, `SERVICE_ROLE_KEY`, `ANON_KEY_ASYMMETRIC`, and `SERVICE_ROLE_KEY_ASYMMETRIC` are now generated with a 5-year expiry.
- `JWTExpSec` is still used only by the `sync-jwt` job to set `app.settings.jwt_exp` on the Postgres database.

## Notes

This change only affects new projects or projects where the `<project>-jwt` Secret is recreated. Existing projects with an already-expired `ANON_KEY` will continue to see 403s until the Secret is regenerated. A follow-up could add logic to automatically rotate expired API keys while preserving immutable keys such as `jwt-secret` and `jwt-keys`.

## Verification

- `make lint-fix` — clean
- `make test` — all tests pass
- `make manifests` — no diff
- `make generate` — no diff