### PR TITLE
feat(db): make statefulset serviceName and data subPath configurable

### DIFF
--- a/charts/supabase/templates/db/statefulset.yaml
+++ b/charts/supabase/templates/db/statefulset.yaml
@@ -20,7 +20,11 @@ spec:
   selector:
     matchLabels:
       {{- include "supabase.db.selectorLabels" . | nindent 6 }}
+  {{- if hasKey .Values.deployment.db "serviceName" }}
+  serviceName: {{ .Values.deployment.db.serviceName | quote }}
+  {{- else }}
   serviceName: {{ include "supabase.db.fullname" . }}
+  {{- end }}
   template:
     metadata:
       labels:
@@ -164,7 +168,9 @@ spec:
             {{- if .Values.persistence.db.enabled }}
             - mountPath: /var/lib/postgresql/data
               name: postgres-volume
-              subPath: postgres-data
+              {{- with .Values.persistence.db.subPath }}
+              subPath: {{ . }}
+              {{- end }}
             {{- end }}
           {{- with .Values.deployment.db.livenessProbe }}
           livenessProbe:

--- a/charts/supabase/values.yaml
+++ b/charts/supabase/values.yaml
@@ -289,6 +289,8 @@ deployment:
     replicaCount: 1
     nameOverride: ""
     fullnameOverride: ""
+    ## Override the immutable StatefulSet serviceName; defaults to the db fullname
+    # serviceName: ""
     labels: {}
     annotations: {}
     podAnnotations: {}
@@ -929,6 +931,7 @@ persistence:
     enabled: true
     storageClassName: ""
     # existingClaim: ""
+    subPath: postgres-data
     annotations: {}
     size: 5Gi
     accessModes:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature (opt-in, backward compatible).

## What is the current behavior?

Closes #241. The `db` StatefulSet hardcodes two values: `serviceName` (always `supabase.db.fullname`) and the data mount's `subPath` (always `postgres-data`). Since a StatefulSet's `serviceName` is immutable, any existing install whose object carries a different (or empty) value fails `helm upgrade` with a "field is immutable" error, and volumes provisioned with data at a different location (e.g. the volume root) can't be mounted correctly.

## What is the new behavior?

Adds two optional values, both unset by default so the default render is unchanged:

- `deployment.db.serviceName`: used verbatim when the key is present (including an explicit `""`, which some legacy StatefulSets need to reproduce in order to upgrade in place); falls back to `supabase.db.fullname` when absent.
- `persistence.db.subPath`: defaults to `postgres-data`; setting it to `""` mounts the volume root.

## Additional context

`helm lint` passes and the default `helm template` output is byte-identical to main.
