### PR TITLE
ci: add automated release pipeline for operator image and installer

### DIFF
--- a/.github/workflows/lint-operator.yaml
+++ b/.github/workflows/lint-operator.yaml
@@ -1,7 +1,6 @@
 name: Lint
 
 on:
-  push:
   pull_request:
 
 jobs:

--- a/.github/workflows/release-operator.yaml
+++ b/.github/workflows/release-operator.yaml
@@ -7,7 +7,6 @@ on:
       - develop
     tags:
       - "v*"
-  workflow_dispatch: {}
 
 permissions:
   contents: write

--- a/.github/workflows/release-operator.yaml
+++ b/.github/workflows/release-operator.yaml
@@ -1,0 +1,85 @@
+name: release-operator
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+    tags:
+      - "v*"
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  packages: write
+
+concurrency:
+  group: release-operator-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/supabase-operator
+
+jobs:
+  docker:
+    name: Build and push image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=sha
+            type=semver,pattern={{version}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  release:
+    name: Create GitHub Release
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: docker
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build installer
+        run: make build-installer IMG=${IMAGE_NAME}:${GITHUB_REF_NAME#v}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          generate_release_notes: true
+          files: dist/install.yaml

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -1,7 +1,6 @@
 name: E2E Tests
 
 on:
-  push:
   pull_request:
 
 jobs:

--- a/.github/workflows/test-operator.yaml
+++ b/.github/workflows/test-operator.yaml
@@ -1,7 +1,6 @@
 name: Tests
 
 on:
-  push:
   pull_request:
 
 jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # Build the manager binary
-FROM golang:1.25 AS builder
+# --platform=${BUILDPLATFORM} runs the Go toolchain natively and cross-compiles
+# (CGO is disabled), avoiding slow QEMU emulation for multi-arch buildx builds.
+FROM --platform=${BUILDPLATFORM} golang:1.25 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/README.md
+++ b/README.md
@@ -41,9 +41,6 @@ Before you begin, make sure you have:
 - A Kubernetes cluster (1.28+ recommended)
 - `kubectl` configured to connect to your cluster
 - `helm` 3.x+
-- `make`
-- Docker (or another container runtime supported by the Makefile `CONTAINER_TOOL` variable)
-- A container registry accessible from your cluster, because you must build and push the Operator image before deploying it
 
 Add the Supabase Helm repository:
 
@@ -54,21 +51,12 @@ helm repo update
 
 ### Deploy the Operator
 
-The Operator is not published as a pre-built image, so you must build and push it yourself. Run:
-
-```bash
-make docker-build IMG=example.com/supabase-operator:v0.0.1
-make docker-push IMG=example.com/supabase-operator:v0.0.1
-```
-
-Then deploy the Operator into the `supabase-operator` namespace:
+Deploy the Operator into the `supabase-operator` namespace:
 
 ```bash
 helm install supabase-operator supabase/supabase-operator \
   --namespace supabase-operator \
-  --create-namespace \
-  --set manager.image.repository=example.com/supabase-operator \
-  --set manager.image.tag=v0.0.1
+  --create-namespace
 ```
 
 This installs the CRDs and deploys the controller in a single step.

--- a/charts/supabase-operator/templates/_helpers.tpl
+++ b/charts/supabase-operator/templates/_helpers.tpl
@@ -48,3 +48,11 @@ Dynamically calculates safe truncation to ensure total name length <= 63 chars.
 {{- printf "%s-%s" $fullname $suffix | trunc 63 | trimSuffix "-" }}
 {{- end }}
 {{- end }}
+
+{{/*
+Manager image reference.
+Tag defaults to "v<chart version>" when .Values.manager.image.tag is not set.
+*/}}
+{{- define "supabase-operator.image" -}}
+{{- printf "%s:%s" .Values.manager.image.repository (default (printf "v%s" .Chart.Version) .Values.manager.image.tag) -}}
+{{- end }}

--- a/charts/supabase-operator/templates/manager/manager.yaml
+++ b/charts/supabase-operator/templates/manager/manager.yaml
@@ -49,7 +49,7 @@ spec:
         {{- end }}
         command:
         - /manager
-        image: "{{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag }}"
+        image: {{ include "supabase-operator.image" . | quote }}
         imagePullPolicy: {{ .Values.manager.image.pullPolicy }}
         livenessProbe:
           httpGet:

--- a/charts/supabase-operator/values.yaml
+++ b/charts/supabase-operator/values.yaml
@@ -12,8 +12,9 @@ manager:
   replicas: 1
 
   image:
-    repository: repository/placeholder
-    tag: latest
+    repository: ghcr.io/supabase-community/supabase-operator
+    # Tag defaults to "v<chart version>" (see _helpers.tpl)
+    tag: null
     pullPolicy: IfNotPresent
 
   ## Arguments


### PR DESCRIPTION
## Summary

This PR introduces a GitHub Actions release pipeline for the supabase-operator manager and a small Dockerfile fix for efficient multi-arch builds.

Related: #239 

## Changes

- **ci(release):** add `.github/workflows/release-operator.yaml`
  - Build and push multi-arch (`linux/amd64`, `linux/arm64`) operator images to GHCR on pushes to `main`, `develop`, and version tags.
  - Use Docker metadata action to tag images by branch, SHA, semver, and `latest` on tag pushes.
  - For semver tags, run `make build-installer` and attach `dist/install.yaml` to the GitHub Release.

- **fix(docker):** use `--platform=${BUILDPLATFORM}` in the builder stage
  - Runs the Go toolchain natively while cross-compiling to `TARGETOS`/`TARGETARCH` (CGO is disabled).
  - Avoids slow QEMU emulation during multi-arch `buildx` builds.

- **ci(cleanup):** remove redundant `push` triggers
  - Drop `push` events from lint, test, and e2e workflows to avoid duplicate CI runs on branch pushes.
  - Remove `workflow_dispatch` from the release workflow.

## Verification

- [x] `make build-installer` succeeds locally
- [x] Docker multi-arch build works with `docker buildx build --platform linux/amd64,linux/arm64`