### PR TITLE
fix: apply securityContext values to initContainers

### DIFF
--- a/charts/supabase/templates/analytics/deployment.yaml
+++ b/charts/supabase/templates/analytics/deployment.yaml
@@ -70,6 +70,8 @@ spec:
               sleep 2
               done
             - echo "Database is ready"
+          securityContext:
+            {{- toYaml .Values.deployment.analytics.securityContext | nindent 12 }}
       {{- end }}
       {{- with .Values.deployment.analytics.extraInitContainers }}
           {{- toYaml . | nindent 8 }}

--- a/charts/supabase/templates/auth/deployment.yaml
+++ b/charts/supabase/templates/auth/deployment.yaml
@@ -77,6 +77,8 @@ spec:
               sleep 2
               done
             - echo "Database is ready"
+          securityContext:
+            {{- toYaml .Values.deployment.auth.securityContext | nindent 12 }}
       {{- end }}
       {{- with .Values.deployment.auth.extraInitContainers }}
           {{- toYaml . | nindent 8 }}

--- a/charts/supabase/templates/realtime/deployment.yaml
+++ b/charts/supabase/templates/realtime/deployment.yaml
@@ -77,6 +77,8 @@ spec:
               sleep 2
               done
             - echo "Database is ready"
+          securityContext:
+            {{- toYaml .Values.deployment.realtime.securityContext | nindent 12 }}
       {{- end }}
       {{- with .Values.deployment.realtime.extraInitContainers }}
           {{- toYaml . | nindent 8 }}

--- a/charts/supabase/templates/rest/deployment.yaml
+++ b/charts/supabase/templates/rest/deployment.yaml
@@ -70,6 +70,8 @@ spec:
               sleep 2
               done
             - echo "Database is ready"
+          securityContext:
+            {{- toYaml .Values.deployment.rest.securityContext | nindent 12 }}
       {{- end }}
       {{- with .Values.deployment.rest.extraInitContainers }}
           {{- toYaml . | nindent 8 }}

--- a/charts/supabase/templates/storage/deployment.yaml
+++ b/charts/supabase/templates/storage/deployment.yaml
@@ -70,6 +70,8 @@ spec:
               sleep 2
               done
             - echo "Database is ready"
+          securityContext:
+            {{- toYaml .Values.deployment.storage.securityContext | nindent 12 }}
       {{- end }}
       {{- if .Values.deployment.minio.enabled }}
         - name: init-bucket


### PR DESCRIPTION
## What kind of change does this PR introduce?

The deployment.[component].securityContext is not applied to initContainers preventing deployment on restricted clusters.

## What is the current behavior?

Deployments except db don't apply the securityContext defined in values to initContainers, thus preventing the deployment on restricted cluster (for instance clusters using restricted PSS)

## What is the new behavior?

The securityContext defined in values is applied on initContainers similar to containers
