### PR TITLE
fix(envoy): route Realtime requests to default tenant

### DIFF
--- a/internal/project/envoy_configmap.go
+++ b/internal/project/envoy_configmap.go
@@ -196,7 +196,7 @@ func envoyServiceHost(project *supabasev1alpha1.Project, serviceName string) str
 	return fmt.Sprintf("%s.%s.svc.cluster.local", serviceName, project.Namespace)
 }
 
-// envoyRealtimeHost returns the fully qualified DNS name for the Realtime service.
-func envoyRealtimeHost(project *supabasev1alpha1.Project) string {
-	return envoyServiceHost(project, RealtimeServiceName(project))
+// envoyRealtimeHost returns the host used to select Realtime's default self-hosted tenant.
+func envoyRealtimeHost(_ *supabasev1alpha1.Project) string {
+	return "realtime-dev.supabase-realtime"
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

Envoy rewrites Realtime requests with internal Kubernetes Service DNS:

```text
<project>-realtime.<namespace>.svc.cluster.local
```
This host lacks Realtime tenant subdomain. Realtime cannot resolve requests to default self-hosted tenant, realtime-dev.
## What is the new behavior?
Envoy now rewrites Realtime request hosts to:
- realtime-dev.supabase-realtime
- This selects default realtime-dev tenant for /realtime/v1/api and WebSocket routes.
- SELF_HOST_TENANT_NAME is not set because Realtime already defaults it to realtime-dev.