### PR TITLE
fix(db): seed postgresql-custom idempotently instead of empty-dir check

### DIFF
--- a/charts/supabase/Chart.yaml
+++ b/charts/supabase/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.2
+version: 0.7.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/supabase/templates/db/statefulset.yaml
+++ b/charts/supabase/templates/db/statefulset.yaml
@@ -62,13 +62,15 @@ spec:
           command: ["/bin/sh", "-c"]
           args:
             - |
-              echo "Initializing pgsodium persistent config directory..."
-              if [ -z "$(ls -A /mnt/pgsodium 2>/dev/null)" ]; then
-                echo "pgsodium volume is empty, copying default postgresql-custom files..."
-                cp -a /etc/postgresql-custom/. /mnt/pgsodium/
-              else
-                echo "pgsodium volume already initialized, skipping copy"
-              fi
+              echo "Ensuring default postgresql-custom files exist..."
+              # Idempotent, no-clobber copy: seeds any missing config files without
+              # overwriting existing ones (preserves runtime-generated pgsodium keys).
+              # An emptiness check ([ -z "$(ls -A)" ]) is unreliable here: block-storage
+              # volumes (EBS, GCE PD, Ceph RBD, OpenEBS LVM, ...) are formatted ext4/xfs
+              # and ship a lost+found directory, so the volume is never truly empty on
+              # first use, the copy was skipped, and postgres could not open its
+              # included /etc/postgresql-custom/*.conf files (CrashLoopBackOff).
+              cp -an /etc/postgresql-custom/. /mnt/pgsodium/ 2>/dev/null || true
           volumeMounts:
             - mountPath: /mnt/pgsodium
               name: pgsodium


### PR DESCRIPTION

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The `init-pgsodium` container copies default `/etc/postgresql-custom` config
files only when the pgsodium volume is empty (`[ -z "$(ls -A)" ]`). On
block-storage volumes (OpenEBS LVM, AWS EBS, GCE PD, Ceph RBD, ...) the
ext4/xfs filesystem ships a `lost+found` directory, so the volume is never
truly empty on first use. The copy is skipped, the config files are missing,
and postgres fails to start:

```
FATAL: configuration file "/etc/postgresql/postgresql.conf" contains errors
could not open configuration file "/etc/postgresql-custom/wal-g.conf": No such file or directory
```

Result: db StatefulSet in CrashLoopBackOff on any block-backed StorageClass.

Fixes #248.

## What is the new behavior?

Replace the emptiness check with an idempotent, no-clobber copy:

```sh
cp -an /etc/postgresql-custom/. /mnt/pgsodium/ 2>/dev/null || true
```

- `-n` (no-clobber) never overwrites existing files, so runtime-generated
  pgsodium keys are preserved across restarts (the reason #197 added the
  persistent volume).
- Missing config files are seeded on every start, so a pre-existing
  `lost+found` no longer blocks the copy.
- Works the same on `emptyDir` and block-backed volumes.

## Additional context

Verified `cp -an` idempotency locally: a runtime-modified file is preserved,
a missing file is re-seeded, and a `lost+found` directory has no effect.
`helm lint` passes and templates render. Chart version bumped 0.7.2 -> 0.7.3.