### PR TITLE
fix: propagate Storage securityContext to init-bucket

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -16,6 +16,9 @@ jobs:
         with:
           version: v3.12.1
 
+      - name: Test Storage init-container securityContext propagation
+        run: bash hack/test-storage-init-security-context.sh
+
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.6.0
 

--- a/charts/supabase/templates/storage/deployment.yaml
+++ b/charts/supabase/templates/storage/deployment.yaml
@@ -98,6 +98,8 @@ spec:
                 sleep 2
               done
               /usr/bin/mc mb --ignore-existing supa-minio/$GLOBAL_S3_BUCKET
+          securityContext:
+            {{- toYaml .Values.deployment.storage.securityContext | nindent 12 }}
         {{- end }}
         {{- with .Values.deployment.storage.extraInitContainers }}
           {{ . | toYaml | nindent 8 }}

--- a/hack/test-storage-init-security-context.sh
+++ b/hack/test-storage-init-security-context.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+rendered_manifest="$(mktemp)"
+trap 'rm -f "${rendered_manifest}"' EXIT
+
+helm template supabase "${repository_root}/charts/supabase" \
+  --namespace default \
+  --kube-version 1.31.0 \
+  --skip-tests \
+  --show-only templates/storage/deployment.yaml \
+  --set deployment.minio.enabled=true \
+  --set deployment.storage.enabled=true \
+  --set deployment.storage.initDb=true \
+  --set deployment.storage.securityContext.allowPrivilegeEscalation=false \
+  --set deployment.storage.securityContext.privileged=false \
+  --set deployment.storage.securityContext.readOnlyRootFilesystem=true \
+  --set deployment.storage.securityContext.runAsNonRoot=true \
+  --set deployment.storage.securityContext.runAsUser=10001 \
+  --set deployment.storage.securityContext.seccompProfile.type=RuntimeDefault \
+  > "${rendered_manifest}"
+
+assert_security_context() {
+  local container_name="$1"
+
+  if ! awk -v target="${container_name}" '
+    /^        - name: / {
+      if (in_target) {
+        exit
+      }
+      if ($0 == "        - name: " target) {
+        in_target = 1
+        found = 1
+      }
+      next
+    }
+    in_target && /^      containers:/ { exit }
+    in_target && /^          securityContext:$/ { context = 1 }
+    in_target && /^            allowPrivilegeEscalation: false$/ { allow = 1 }
+    in_target && /^            privileged: false$/ { privileged = 1 }
+    in_target && /^            readOnlyRootFilesystem: true$/ { readonly = 1 }
+    in_target && /^            runAsNonRoot: true$/ { nonroot = 1 }
+    in_target && /^            runAsUser: 10001$/ { user = 1 }
+    in_target && /^              type: RuntimeDefault$/ { seccomp = 1 }
+    END {
+      if (!(found && context && allow && privileged && readonly && nonroot && user && seccomp)) {
+        exit 1
+      }
+    }
+  ' "${rendered_manifest}"; then
+    echo "Expected propagated Storage securityContext on ${container_name}" >&2
+    return 1
+  fi
+}
+
+assert_security_context init-db
+assert_security_context init-bucket


### PR DESCRIPTION
## Summary

- Apply `deployment.storage.securityContext` to the built-in Storage `init-bucket` init container.
- Add a focused Helm render regression asserting that both built-in Storage init containers receive the configured context.

#245 added Storage init-container securityContext propagation. Current main applies it to `init-db`, but the same Deployment also contains the built-in `init-bucket` init container when MinIO is enabled, and that container still renders without the configured context.

This change applies the same existing Storage context consistently to both built-in init containers without changing the values interface or other chart behavior.

## Testing

- `bash hack/test-storage-init-security-context.sh`
- `helm lint charts/supabase`
- MinIO/Storage configured-context `helm lint`
- `chart-testing:v3.7.1 ct lint`
- Two isolated, byte-identical Helm renders (51 resources)
- IaC-Guard-V `0.1.0a7` with Checkov `3.3.0`: `CKV_K8S_20`, `CKV_K8S_22`, and `CKV_K8S_30` changed from one current-main occurrence on `init-bucket` to zero patched occurrences; parser and scanner integrity passed.

Historical #245 reproduction:
https://github.com/lokesh0186/iac-guard-v/tree/e63ed4a469dd739b213c6b289dfb19aefe4dcfd6/examples/public-reproductions/supabase-kubernetes-245
