### PR TITLE
feat: supabase project examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The Operator exposes the following Kubernetes Custom Resources:
 | `Migration` | `migrations` | Applies SQL scripts to referenced databases. Also used internally by the Operator to manage Supabase upgrade migrations |
 | `Auth` | `auths` | Supabase Auth component |
 | `Rest` | `rests` | PostgREST component |
-| `Meta` | `meta` | Postgres Meta component |
+| `Meta` | `metas` | Postgres Meta component |
 | `Realtime` | `realtimes` | Supabase Realtime component |
 | `Storage` | `storages` | Supabase Storage component |
 | `Studio` | `studios` | Supabase Studio component |

--- a/charts/supabase-project/examples/aws-s3.yaml
+++ b/charts/supabase-project/examples/aws-s3.yaml
@@ -1,0 +1,31 @@
+# Use an existing AWS S3 bucket as the Storage backend.
+#
+# Before installing this example, create the bucket and a Secret in the release
+# namespace. Do not put AWS credentials in this file or commit them to Git:
+#
+# kubectl -n <namespace> create secret generic aws-s3-credentials \
+#   --from-literal=access-key-id='<access-key-id>' \
+#   --from-literal=secret-access-key='<secret-access-key>'
+#
+# The IAM identity needs permission to list the bucket and read, write, and
+# delete its objects. Set the bucket name and region below to their AWS values.
+# AWS S3 resolves its endpoint from REGION, so GLOBAL_S3_ENDPOINT and
+# GLOBAL_S3_FORCE_PATH_STYLE are intentionally omitted.
+storage:
+  config:
+    - name: STORAGE_BACKEND
+      value: s3
+    - name: GLOBAL_S3_BUCKET
+      value: <bucket-name>
+    - name: REGION
+      value: <aws-region>
+    - name: AWS_ACCESS_KEY_ID
+      valueFrom:
+        secretKeyRef:
+          name: aws-s3-credentials
+          key: access-key-id
+    - name: AWS_SECRET_ACCESS_KEY
+      valueFrom:
+        secretKeyRef:
+          name: aws-s3-credentials
+          key: secret-access-key

--- a/charts/supabase-project/examples/imgproxy.yaml
+++ b/charts/supabase-project/examples/imgproxy.yaml
@@ -48,4 +48,4 @@ storage:
             # This is the operator-managed Storage PVC, also mounted by Storage.
             - name: storage-data
               mountPath: /var/lib/storage
-              subPath: data
+              subPath: storage-data

--- a/charts/supabase-project/examples/imgproxy.yaml
+++ b/charts/supabase-project/examples/imgproxy.yaml
@@ -1,0 +1,51 @@
+# Enable image transformations in Storage through an imgproxy sidecar.
+# Containers in the same Pod share a network namespace, so Storage reaches
+# imgproxy through localhost rather than a Kubernetes Service.
+
+storage:
+  config:
+    - name: ENABLE_IMAGE_TRANSFORMATION
+      value: "true"
+    - name: IMGPROXY_URL
+      value: http://127.0.0.1:5001
+  pod:
+    spec:
+      containers:
+        - name: imgproxy
+          image: darthsim/imgproxy:v3.30.1
+          ports:
+            - name: http
+              containerPort: 5001
+              protocol: TCP
+          env:
+            - name: IMGPROXY_BIND
+              value: ":5001"
+            - name: IMGPROXY_LOCAL_FILESYSTEM_ROOT
+              value: /
+            - name: IMGPROXY_USE_ETAG
+              value: "true"
+            - name: IMGPROXY_AUTO_WEBP
+              value: "true"
+            - name: IMGPROXY_MAX_SRC_RESOLUTION
+              value: "16.8"
+          livenessProbe:
+            exec:
+              command:
+                - imgproxy
+                - health
+            timeoutSeconds: 5
+            periodSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+                - imgproxy
+                - health
+            timeoutSeconds: 5
+            periodSeconds: 5
+            failureThreshold: 3
+          volumeMounts:
+            # This is the operator-managed Storage PVC, also mounted by Storage.
+            - name: storage-data
+              mountPath: /var/lib/storage
+              subPath: data

--- a/charts/supabase-project/examples/rustfs.yaml
+++ b/charts/supabase-project/examples/rustfs.yaml
@@ -1,5 +1,11 @@
-# Demonstration-only credentials. Replace them before using this configuration
-# outside a local or development cluster.
+# Use RustFS as an S3-compatible backend for Storage.
+#
+# Before installing this example, create a Secret in the release namespace.
+# Do not put access keys directly in this file or commit them to Git:
+#
+# kubectl -n <namespace> create secret generic rustfs-credentials \
+#   --from-literal=access-key-id='<access-key-id>' \
+#   --from-literal=secret-access-key='<secret-access-key>'
 #
 # This example requires Kubernetes 1.29+ for native sidecar init containers.
 # RustFS starts first and remains running, rustfs-createbucket then creates the
@@ -19,9 +25,15 @@ storage:
     - name: REGION
       value: us-east-1
     - name: AWS_ACCESS_KEY_ID
-      value: supa-storage
+      valueFrom:
+        secretKeyRef:
+          name: rustfs-credentials
+          key: access-key-id
     - name: AWS_SECRET_ACCESS_KEY
-      value: secret1234
+      valueFrom:
+        secretKeyRef:
+          name: rustfs-credentials
+          key: secret-access-key
   pod:
     spec:
       initContainers:
@@ -39,9 +51,15 @@ storage:
               protocol: TCP
           env:
             - name: RUSTFS_ACCESS_KEY
-              value: supa-storage
+              valueFrom:
+                secretKeyRef:
+                  name: rustfs-credentials
+                  key: access-key-id
             - name: RUSTFS_SECRET_KEY
-              value: secret1234
+              valueFrom:
+                secretKeyRef:
+                  name: rustfs-credentials
+                  key: secret-access-key
             - name: RUSTFS_CONSOLE_ADDRESS
               value: 0.0.0.0:9001
             - name: RUSTFS_CORS_ALLOWED_ORIGINS
@@ -88,8 +106,14 @@ storage:
               done
           env:
             - name: AWS_ACCESS_KEY_ID
-              value: supa-storage
+              valueFrom:
+                secretKeyRef:
+                  name: rustfs-credentials
+                  key: access-key-id
             - name: AWS_SECRET_ACCESS_KEY
-              value: secret1234
+              valueFrom:
+                secretKeyRef:
+                  name: rustfs-credentials
+                  key: secret-access-key
           securityContext:
             allowPrivilegeEscalation: false

--- a/charts/supabase-project/examples/rustfs.yaml
+++ b/charts/supabase-project/examples/rustfs.yaml
@@ -1,0 +1,95 @@
+# Demonstration-only credentials. Replace them before using this configuration
+# outside a local or development cluster.
+#
+# This example requires Kubernetes 1.29+ for native sidecar init containers.
+# RustFS starts first and remains running, rustfs-createbucket then creates the
+# bucket, and finally the operator-managed Storage container starts.
+storage:
+  config:
+    - name: STORAGE_BACKEND
+      value: s3
+    - name: GLOBAL_S3_BUCKET
+      value: stub
+    - name: GLOBAL_S3_ENDPOINT
+      value: http://127.0.0.1:9000
+    - name: GLOBAL_S3_PROTOCOL
+      value: http
+    - name: GLOBAL_S3_FORCE_PATH_STYLE
+      value: "true"
+    - name: REGION
+      value: us-east-1
+    - name: AWS_ACCESS_KEY_ID
+      value: supa-storage
+    - name: AWS_SECRET_ACCESS_KEY
+      value: secret1234
+  pod:
+    spec:
+      initContainers:
+        # A native sidecar init container keeps RustFS running for the lifetime
+        # of the Pod while allowing the next init container to create its bucket.
+        - name: rustfs
+          image: rustfs/rustfs:1.0.0-beta.11
+          restartPolicy: Always
+          ports:
+            - name: s3
+              containerPort: 9000
+              protocol: TCP
+            - name: console
+              containerPort: 9001
+              protocol: TCP
+          env:
+            - name: RUSTFS_ACCESS_KEY
+              value: supa-storage
+            - name: RUSTFS_SECRET_KEY
+              value: secret1234
+            - name: RUSTFS_CONSOLE_ADDRESS
+              value: 0.0.0.0:9001
+            - name: RUSTFS_CORS_ALLOWED_ORIGINS
+              value: "*"
+            - name: RUSTFS_CONSOLE_CORS_ALLOWED_ORIGINS
+              value: "*"
+          startupProbe:
+            httpGet:
+              path: /health
+              port: s3
+            periodSeconds: 2
+            timeoutSeconds: 10
+            failureThreshold: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: s3
+            periodSeconds: 2
+            timeoutSeconds: 10
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: s3
+            periodSeconds: 2
+            timeoutSeconds: 10
+            failureThreshold: 5
+          securityContext:
+            allowPrivilegeEscalation: false
+          volumeMounts:
+            # Reuse the Storage PVC without sharing its file backend directory.
+            - name: storage-data
+              mountPath: /data
+              subPath: rustfs-data
+        - name: rustfs-createbucket
+          image: rustfs/rc:v0.1.29
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              until rc alias set supa-rustfs http://127.0.0.1:9000 "$AWS_ACCESS_KEY_ID" "$AWS_SECRET_ACCESS_KEY" && rc mb --ignore-existing supa-rustfs/stub; do
+                echo "Waiting for RustFS and bucket creation"
+                sleep 2
+              done
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              value: supa-storage
+            - name: AWS_SECRET_ACCESS_KEY
+              value: secret1234
+          securityContext:
+            allowPrivilegeEscalation: false


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature: adds ready-to-use Helm values examples for Storage image transformations and a RustFS S3 backend.

## What is the current behavior?

The `supabase-project` chart does not provide examples for running imgproxy alongside Storage or for using RustFS as Storage's S3-compatible backend.

## What is the new behavior?

- Adds an imgproxy sidecar example that shares the Storage PVC and enables image transformations through `IMGPROXY_URL`.
- Adds a RustFS example that runs RustFS as a native sidecar init container, creates the S3 bucket before Storage starts, and persists RustFS data on the Storage PVC.
- The RustFS example requires Kubernetes 1.29+ and includes demonstration-only credentials for local or development clusters.

## Additional context

Validated both examples with `helm lint charts/supabase-project` and `helm template` using each example values file.
